### PR TITLE
Temporarily pin Pydantic to under 2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "linkml @ git+https://github.com/candleindark/linkml.git@bundle-error",
-  "pydantic~=2.7",
+  "pydantic~=2.7,<2.11",
   "typer",
 ]
 


### PR DESCRIPTION
See individual commit message for details