### PR TITLE
build: drop Python 3.9, add 3.13, expand CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
           - macos-latest
           - windows-latest
           - ubuntu-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -27,9 +32,8 @@ jobs:
         uses: pypa/hatch@install
 
       - name: Run tests
-        run: hatch run test:python -m pytest --numprocesses=logical -s -v tests
+        run: hatch run test.py${{ matrix.python-version }}:python -m pytest --numprocesses=logical -s -v tests
         env:
-          # Needed for coveralls:
           GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 # vim:set et sts=2:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Keeping Documentation Up to Date
+
+- Whenever you notice that any documentation — `CLAUDE.md`, `README.md`, or any other
+  docs for human or machine consumption — is outdated or incorrect (e.g., Python
+  versions, dependencies, commands, architecture descriptions), update it immediately.
+- Before submitting a PR, review **all project documentation** and ensure everything
+  is accurate and up to date.
+- Wrap all prose in documentation files at ~79 characters so they read well as
+  plain text. Code blocks and long URLs are exempt.
+
 ## Project Overview
 
 `pydantic2linkml` is a CLI tool and library that translates [Pydantic](https://docs.pydantic.dev/) v2 models to [LinkML](https://linkml.io/) schemas. It works by introspecting Pydantic's internal `core_schema` objects rather than the higher-level model API.
@@ -11,20 +21,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This project uses [Hatch](https://hatch.pypa.io/) for environment and build management.
 
 ```bash
-# Install Hatch
-pip install hatch
+# Check if Hatch is already installed (it may be installed via Homebrew, pipx, pip, etc.)
+hatch --version
 
-# Run tests (in the test environment)
-hatch run test:pytest tests/
+# If not installed, see https://hatch.pypa.io/latest/install/ for options, e.g.:
+#   brew install hatch        # macOS/Linux via Homebrew
+#   pipx install hatch        # isolated pip install (recommended)
+#   pip install hatch         # plain pip
+
+# Run tests in a specific Python environment
+hatch run test.py3.10:pytest tests/
 
 # Run a single test file
-hatch run test:pytest tests/test_gen_linkml.py
+hatch run test.py3.10:pytest tests/test_gen_linkml.py
 
 # Run a single test by name
-hatch run test:pytest tests/test_gen_linkml.py::test_name
+hatch run test.py3.10:pytest tests/test_gen_linkml.py::test_name
 
 # Run tests with coverage
-hatch run test:pytest --cov tests/
+hatch run test.py3.10:pytest --cov tests/
+
+# Run tests across all Python matrix environments
+hatch run test:python -m pytest --numprocesses=logical -s -v tests
 
 # Type checking
 hatch run types:check
@@ -37,7 +55,7 @@ ruff format .
 codespell
 ```
 
-The default hatch environment uses Python 3.9. The `test` environment adds `aind-data-schema`, `dandischema`, `pytest`, `pytest-cov`, `pytest-mock`, and `pytest-xdist`.
+The default hatch environment uses Python 3.10. The `test` environment matrix covers Python 3.10–3.13 and adds `aind-data-schema`, `dandischema`, `pytest`, `pytest-cov`, `pytest-mock`, and `pytest-xdist`.
 
 ## CLI Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pydantic2linkml"
 dynamic = ["version"]
 description = 'A tool for translating models expressed in Pydantic to LinkML'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"  # todo: Is this the correct license?
 keywords = ["LinkML", "Pydantic"]
 authors = [
@@ -20,10 +20,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
@@ -47,7 +47,10 @@ path = "src/pydantic2linkml/__about__.py"
 allow-direct-references = true
 
 [tool.hatch.envs.default]
-python = "3.9"
+python = "3.10"
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.test]
 dependencies = [


### PR DESCRIPTION
## Summary

- Drop Python 3.9 (EOL): bump `requires-python` to `>=3.10`, remove
  3.9 classifier
- Add Python 3.13 support: add classifier, extend Hatch test matrix
  and CI matrix
- CI now runs 3 OS × 4 Python versions (12 jobs) instead of 3 OS × 1
- Python 3.14 is **not** included yet: the `pydantic<2.11` pin forces
  `pydantic-core` ≤2.27.x (PyO3 0.22.x), which tops out at Python
  3.13; 3.14 can be added once pydantic 2.11 compatibility is resolved
- Update `CLAUDE.md`: correct Python versions, update test commands,
  add documentation maintenance and formatting guidance

## Test plan

- [x] `hatch env show` — confirmed `test.py3.10` through `test.py3.13`
  listed
- [x] `hatch run test.py3.10:pytest tests/` — 3291 passed, 14 xfailed
- [x] `hatch run test.py3.11:pytest tests/` — 3291 passed, 14 xfailed
- [x] `hatch run test.py3.12:pytest tests/` — 3291 passed, 14 xfailed
- [x] `hatch run test.py3.13:pytest tests/` — 3291 passed, 14 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)