### PR TITLE
build: use UV as the Hatch package installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ path = "src/pydantic2linkml/__about__.py"
 allow-direct-references = true
 
 [tool.hatch.envs.default]
+installer = "uv"
 python = "3.10"
 
 [[tool.hatch.envs.test.matrix]]


### PR DESCRIPTION
## Summary

- Adds `installer = "uv"` to `[tool.hatch.envs.default]` in `pyproject.toml`
- Because all Hatch environments inherit from `default`, UV is used in the
  `test` and `types` environments as well — no per-environment setting needed
- Requires Hatch ≥ 1.10.0 (introduced in that release), which is already
  satisfied by the `pypa/hatch@install` action used in CI

## Test plan

- [x] Full local test suite passes across Python 3.10–3.13
  (`3291 passed, 14 xfailed` with UV as installer)
- [x] CI matrix (Ubuntu/macOS/Windows × Python 3.10–3.13) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)