### PR TITLE
build: unpin linkml from git branch, use released package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "linkml @ git+https://github.com/candleindark/linkml.git@bundle-error",
+  "linkml",
   "pydantic~=2.7,<2.11",
   "typer",
 ]
@@ -42,9 +42,6 @@ pydantic2linkml = "pydantic2linkml.cli:app"
 
 [tool.hatch.version]
 path = "src/pydantic2linkml/__about__.py"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.envs.default]
 installer = "uv"


### PR DESCRIPTION
## Summary

- Replaces the git+https pin to a custom branch (`candleindark/linkml@bundle-error`) with the standard released `linkml` package. The fix from the custom branch has been merged upstream via https://github.com/linkml/linkml/pull/2363.
- Removes the now-unnecessary `[tool.hatch.metadata] allow-direct-references = true` setting.

Closes #4

## Test plan

- [x] All tests pass on Python 3.10, 3.11, 3.12, and 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)