### PR TITLE
Rename `any_class_def` to `ANY_CLASS_DEF` per Python constant convention

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -68,7 +68,7 @@ sort_dict_by_ikeys = partial(sort_dict, key_func=lambda t: itemgetter(0)(t).case
 
 # The LinkML Any type
 # For more info, see https://linkml.io/linkml/schemas/advanced.html#linkml-any-type
-any_class_def = ClassDefinition(
+ANY_CLASS_DEF = ClassDefinition(
     name="Any", description="Any object", class_uri="linkml:Any"
 )
 
@@ -372,7 +372,7 @@ class LinkmlGenerator:
         Establish the supporting definitions in the schema
         """
         # Add an `linkml:Any` class
-        self._sb.add_class(any_class_def)
+        self._sb.add_class(ANY_CLASS_DEF)
 
 
 class SlotGenerator:
@@ -481,7 +481,7 @@ class SlotGenerator:
 
         :param _schema: The core schema
         """
-        self._slot.range = any_class_def.name
+        self._slot.range = ANY_CLASS_DEF.name
 
     def _none_schema(self, _schema: core_schema.NoneSchema) -> None:
         """
@@ -1141,7 +1141,7 @@ class SlotGenerator:
         # This is needed because of the monotonicity nature of constraints
         #   in LinkML. For more information,
         #   see https://linkml.io/linkml/schemas/advanced.html#unions-as-ranges
-        self._slot.range = any_class_def.name
+        self._slot.range = ANY_CLASS_DEF.name
 
     def _tagged_union_schema(self, schema: core_schema.TaggedUnionSchema) -> None:
         """

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -25,7 +25,7 @@ from pydantic import (
     conlist,
 )
 
-from pydantic2linkml.gen_linkml import LinkmlGenerator, SlotGenerator, any_class_def
+from pydantic2linkml.gen_linkml import LinkmlGenerator, SlotGenerator, ANY_CLASS_DEF
 from pydantic2linkml.tools import (
     fetch_defs,
     get_all_modules,
@@ -906,7 +906,7 @@ class TestSlotGenerator:
 
         slot = translate_field_to_slot(Foo2, "x")
 
-        assert slot.range == any_class_def.name
+        assert slot.range == ANY_CLASS_DEF.name
         assert slot.any_of == [
             AnonymousSlotExpression(range="Bar1"),
             AnonymousSlotExpression(range="Bar2"),


### PR DESCRIPTION
## Summary
- Renames the module-level constant `any_class_def` → `ANY_CLASS_DEF` in
  `gen_linkml.py` to follow PEP 8 naming conventions for constants
- Updates all usages in `gen_linkml.py` (2 sites) and the import + usage in
  `tests/test_gen_linkml.py`

## Test plan
- [x] CI passes on all Python matrix environments (3.10–3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)