### PR TITLE
Remove redundant name/text fields from serialized LinkML YAML

### DIFF
--- a/src/pydantic2linkml/cli/__init__.py
+++ b/src/pydantic2linkml/cli/__init__.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from pydantic2linkml.cli.tools import LogLevel
 from pydantic2linkml.exceptions import OverlayContentError
 from pydantic2linkml.gen_linkml import translate_defs
-from pydantic2linkml.tools import apply_schema_overlay
+from pydantic2linkml.tools import apply_schema_overlay, remove_schema_key_duplication
 
 logger = logging.getLogger(__name__)
 app = typer.Typer()
@@ -41,7 +41,7 @@ def main(
 
     schema = translate_defs(module_names)
     logger.info("Dumping schema")
-    yml = yaml_dumper.dumps(schema)
+    yml = remove_schema_key_duplication(yaml_dumper.dumps(schema))
     if overlay_file is not None:
         logger.info("Applying overlay from %s", overlay_file)
         try:

--- a/src/pydantic2linkml/cli/tools.py
+++ b/src/pydantic2linkml/cli/tools.py
@@ -2,7 +2,6 @@ from pydantic2linkml.tools import StrEnum
 
 
 class LogLevel(StrEnum):
-
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARNING = "WARNING"

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -902,7 +902,7 @@ class SlotGenerator:
         if self._slot.multivalued:
             # === This must be a nested list type ===
             self._attach_note(
-                "Translation is incomplete." "Nested list types are not yet supported."
+                "Translation is incomplete.Nested list types are not yet supported."
             )
             return
 

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -201,9 +201,9 @@ def get_model_schema(model: type[BaseModel]) -> core_schema.ModelSchema:
         else:
             model_schema = inner_schema
 
-    assert (
-        model_schema["type"] == "model"
-    ), "Assumption about how model schema is stored is wrong."
+    assert model_schema["type"] == "model", (
+        "Assumption about how model schema is stored is wrong."
+    )
 
     return cast(core_schema.ModelSchema, model_schema)
 
@@ -248,7 +248,7 @@ def get_field_schema(model: type[BaseModel], fn: str) -> FieldSchema:
     else:
         raise NotImplementedError(
             f"This function currently doesn't support the inner schema of "
-            f"a `ModelSchema` being the type of \"{model_schema['schema']['type']}\""
+            f'a `ModelSchema` being the type of "{model_schema["schema"]["type"]}"'
         )
 
 
@@ -390,7 +390,6 @@ def fetch_defs(
 
     for module in modules:
         for _, cls in inspect.getmembers(module, inspect.isclass):
-
             if (
                 issubclass(cls, BaseModel)
                 and cls is not BaseModel
@@ -579,3 +578,32 @@ def apply_schema_overlay(schema_yml: str, overlay_file: FilePath) -> str:
     ordered = {k: schema_dict[k] for k in sd_field_names if k in schema_dict}
 
     return yaml.dump(ordered, allow_unicode=True, sort_keys=False)
+
+
+def remove_schema_key_duplication(yml: str) -> str:
+    """Remove redundant name/text fields from a valid serialized LinkML schema.
+
+    In LinkML's serialized YAML, dictionary keys already serve as
+    identifiers for classes, slots, enums, slot_usage entries, and
+    permissible values. This function strips the redundant ``name`` and
+    ``text`` fields that the linkml-runtime YAML dumper includes alongside
+    those keys.
+
+    :param yml: A YAML string representing a **valid** LinkML schema.
+    """
+    schema = yaml.safe_load(yml)
+
+    for cls in schema.get("classes", {}).values():
+        cls.pop("name", None)
+        for su in cls.get("slot_usage", {}).values():
+            su.pop("name", None)
+
+    for slot in schema.get("slots", {}).values():
+        slot.pop("name", None)
+
+    for enum in schema.get("enums", {}).values():
+        enum.pop("name", None)
+        for pv in enum.get("permissible_values", {}).values():
+            pv.pop("text", None)
+
+    return yaml.dump(schema, allow_unicode=True, sort_keys=False)

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -437,8 +437,7 @@ class TestSlotGenerator:
             now_op is not None,
         )
         verify_notes(
-            "Unable to express the utc offset of the current date "
-            "in the restriction",
+            "Unable to express the utc offset of the current date in the restriction",
             now_utc_offset is not None,
         )
 
@@ -673,9 +672,7 @@ class TestSlotGenerator:
                 # This is needed due to Pydantic's behavior:
                 # The any argument for `min_length` of `conlist` that is less than
                 # or equal to 0 is ignored.
-                None
-                if (min_len is not None and min_len <= 0)
-                else min_len
+                None if (min_len is not None and min_len <= 0) else min_len
             )
             assert slot.maximum_cardinality == max_len
             assert slot.range == expected_range

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,6 +29,7 @@ from pydantic2linkml.tools import (
     get_slot_usage_entry,
     get_uuid_regex,
     normalize_whitespace,
+    remove_schema_key_duplication,
     resolve_ref_schema,
     sort_dict,
 )
@@ -724,3 +725,78 @@ class TestApplySchemaOverlay:
             schema_yml=SAMPLE_SCHEMA_YML, overlay_file=overlay_file
         )
         assert yaml.safe_load(result)["title"] == "\u00dc n\u00ef c\u00f6d\u00e9"
+
+
+class TestRemoveSchemaKeyDuplication:
+    def test_classes_name_removed(self):
+        schema = {"classes": {"Person": {"name": "Person", "description": "A person"}}}
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        assert "name" not in result["classes"]["Person"]
+        assert result["classes"]["Person"]["description"] == "A person"
+
+    def test_slots_name_removed(self):
+        schema = {"slots": {"age": {"name": "age", "range": "integer"}}}
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        assert "name" not in result["slots"]["age"]
+        assert result["slots"]["age"]["range"] == "integer"
+
+    def test_enums_name_removed(self):
+        schema = {"enums": {"Status": {"name": "Status"}}}
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        assert "name" not in result["enums"]["Status"]
+
+    def test_slot_usage_name_removed(self):
+        schema = {
+            "classes": {
+                "Employee": {
+                    "name": "Employee",
+                    "slot_usage": {"age": {"name": "age", "required": True}},
+                }
+            }
+        }
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        assert "name" not in result["classes"]["Employee"]["slot_usage"]["age"]
+        assert result["classes"]["Employee"]["slot_usage"]["age"]["required"] is True
+
+    def test_permissible_values_text_removed(self):
+        schema = {
+            "enums": {
+                "Status": {
+                    "name": "Status",
+                    "permissible_values": {
+                        "ACTIVE": {"text": "ACTIVE", "description": "Currently active"}
+                    },
+                }
+            }
+        }
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        pv = result["enums"]["Status"]["permissible_values"]["ACTIVE"]
+        assert "text" not in pv
+        assert pv["description"] == "Currently active"
+
+    def test_missing_sections_no_error(self):
+        schema = {"id": "https://example.com/test", "name": "test-schema"}
+        result = yaml.safe_load(remove_schema_key_duplication(yaml.dump(schema)))
+        assert result["id"] == "https://example.com/test"
+
+    def test_round_trip(self):
+        from linkml_runtime.dumpers import yaml_dumper
+        from tests.assets import mock_module0, mock_module1
+
+        from pydantic2linkml.gen_linkml import translate_defs
+
+        schema = translate_defs([mock_module0.__name__, mock_module1.__name__])
+        raw_yml = yaml_dumper.dumps(schema)
+        result_yml = remove_schema_key_duplication(raw_yml)
+        result = yaml.safe_load(result_yml)
+
+        for cls in result.get("classes", {}).values():
+            assert "name" not in cls
+            for su in cls.get("slot_usage", {}).values():
+                assert "name" not in su
+        for slot in result.get("slots", {}).values():
+            assert "name" not in slot
+        for enum in result.get("enums", {}).values():
+            assert "name" not in enum
+            for pv in enum.get("permissible_values", {}).values():
+                assert "text" not in pv


### PR DESCRIPTION
## Summary

- Adds `remove_schema_key_duplication()` in `tools.py` that strips fields whose values duplicate the dictionary key they are keyed under in a serialized LinkML schema:
  - `name` from each entry in `classes`, `slots`, and `enums`
  - `name` from each `slot_usage` entry within a class
  - `text` from each `permissible_values` entry within an enum
- Calls the function in the CLI immediately after `yaml_dumper.dumps()`, before any overlay is applied
- Adds a `TestRemoveSchemaKeyDuplication` test class covering each field type, missing sections, and a round-trip test against the mock modules

Also applies `ruff format` across the codebase.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_tools.py -k "RemoveSchemaKey"` — all 7 new tests pass
- [x] `hatch run test.py3.10:pytest tests/` — 3312 passed, 14 xfailed
- [x] `ruff check .` — no errors
- [x] `hatch run types:check` — no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)