### PR TITLE
Add add_section_breaks utility for readable YAML output

### DIFF
--- a/src/pydantic2linkml/cli/__init__.py
+++ b/src/pydantic2linkml/cli/__init__.py
@@ -9,7 +9,11 @@ from pydantic import ValidationError
 from pydantic2linkml.cli.tools import LogLevel
 from pydantic2linkml.exceptions import OverlayContentError
 from pydantic2linkml.gen_linkml import translate_defs
-from pydantic2linkml.tools import apply_schema_overlay, remove_schema_key_duplication
+from pydantic2linkml.tools import (
+    add_section_breaks,
+    apply_schema_overlay,
+    remove_schema_key_duplication,
+)
 
 logger = logging.getLogger(__name__)
 app = typer.Typer()
@@ -56,6 +60,7 @@ def main(
                 f"The overlay file does not contain a valid YAML mapping: {e}",
                 param_hint="'--overlay-file'",
             ) from e
+    yml = add_section_breaks(yml)
     if not output_file:
         print(yml)  # noqa: T201
     else:

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -607,3 +607,29 @@ def remove_schema_key_duplication(yml: str) -> str:
             pv.pop("text", None)
 
     return yaml.dump(schema, allow_unicode=True, sort_keys=False)
+
+
+def add_section_breaks(
+    yml: str,
+    keys: tuple[str, ...] = ("enums", "slots", "classes"),
+    break_str: str = "\n",
+) -> str:
+    """Insert a break string before selected top-level keys in a YAML string.
+
+    :param yml: A YAML string.
+    :param keys: Top-level keys to precede with a break. Defaults to
+        ``("enums", "slots", "classes")``.
+    :param break_str: String prepended before each matched key line.
+        Defaults to ``"\\n"``, producing a blank line.
+    """
+    if not keys:
+        return yml
+
+    pattern = r"^(" + "|".join(re.escape(k) for k in keys) + r"):"
+
+    def replacement(m: re.Match) -> str:
+        if m.start() == 0:
+            return m.group(0)
+        return break_str + m.group(0)
+
+    return re.sub(pattern, replacement, yml, flags=re.MULTILINE)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,6 +17,7 @@ from pydantic2linkml.exceptions import (
     SlotExtensionError,
 )
 from pydantic2linkml.tools import (
+    add_section_breaks,
     apply_schema_overlay,
     bucketize,
     ensure_unique_names,
@@ -800,3 +801,55 @@ class TestRemoveSchemaKeyDuplication:
             assert "name" not in enum
             for pv in enum.get("permissible_values", {}).values():
                 assert "text" not in pv
+
+
+class TestAddSectionBreaks:
+    @pytest.mark.parametrize(
+        "yml, kwargs, expected",
+        [
+            # blank line inserted before a mid-string key (default keys)
+            (
+                "id: schema\nclasses:\n  Foo: {}\n",
+                {},
+                "id: schema\n\nclasses:\n  Foo: {}\n",
+            ),
+            # no break added when key is at position 0
+            (
+                "classes:\n  Foo: {}\n",
+                {},
+                "classes:\n  Foo: {}\n",
+            ),
+            # all three default keys receive breaks
+            (
+                "id: s\nenums:\n  E: {}\nslots:\n  s: {}\nclasses:\n  C: {}\n",
+                {},
+                "id: s\n\nenums:\n  E: {}\n\nslots:\n  s: {}\n\nclasses:\n  C: {}\n",
+            ),
+            # custom keys
+            (
+                "id: s\nsubsets:\n  sub: {}\n",
+                {"keys": ("subsets",)},
+                "id: s\n\nsubsets:\n  sub: {}\n",
+            ),
+            # custom break_str
+            (
+                "id: s\nclasses:\n  C: {}\n",
+                {"break_str": "\n# ---\n"},
+                "id: s\n\n# ---\nclasses:\n  C: {}\n",
+            ),
+            # indented occurrence of a key name is not matched
+            (
+                "classes:\n  Foo:\n    slots:\n      - bar\n",
+                {},
+                "classes:\n  Foo:\n    slots:\n      - bar\n",
+            ),
+            # empty keys tuple — string unchanged
+            (
+                "id: s\nclasses:\n  C: {}\n",
+                {"keys": ()},
+                "id: s\nclasses:\n  C: {}\n",
+            ),
+        ],
+    )
+    def test_add_section_breaks(self, yml, kwargs, expected):
+        assert add_section_breaks(yml, **kwargs) == expected


### PR DESCRIPTION
## Summary

- Adds `add_section_breaks(yml, keys, break_str)` to `tools.py`, which
  inserts a blank line before selected top-level YAML keys (`enums`,
  `slots`, `classes` by default).
- Calls `add_section_breaks` in the CLI after the optional overlay step,
  so all top-level sections — including any added by an overlay — receive
  spacing.
- Adds `TestAddSectionBreaks` with 7 parametrized cases covering: mid-
  string keys, position-0 skip, all three default keys, custom keys,
  custom `break_str`, indented key non-match, and empty keys tuple.

Closes #31.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_tools.py::TestAddSectionBreaks -v` — all 7 pass
- [x] `hatch run test.py3.10:pytest tests/` — 3319 passed, 14 xfailed, no regressions
- [x] `ruff check` — no issues
- [x] `hatch run types:check` — no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)