### PR TITLE
Set LinkML class description from Pydantic model docstrings

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -360,6 +360,9 @@ class LinkmlGenerator:
 
         return ClassDefinition(
             model.__name__,
+            description=(
+                normalize_whitespace(model.__doc__) if model.__doc__ else None
+            ),
             is_a=is_a,
             mixins=mixins,
             slots=slots,

--- a/tests/assets/mock_module0.py
+++ b/tests/assets/mock_module0.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, RootModel
 
 
 class A(BaseModel):
+    """Model A docstring."""
+
     pass
 
 

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -166,6 +166,24 @@ class TestLinkmlGenerator:
     def test_generate(self, linkml_generator):
         linkml_generator.generate()
 
+    def test_class_description_from_docstring(self):
+        """
+        Test that a model with a docstring produces a ClassDefinition with the
+        correct description, and a model without a docstring produces
+        description=None.
+        """
+        from tests.assets.mock_module0 import A, B
+
+        models = [A, B]
+        generator = LinkmlGenerator(models=models, enums=[])
+        schema = generator.generate()
+
+        class_a = schema.classes["A"]
+        assert class_a.description == "Model A docstring."
+
+        class_b = schema.classes["B"]
+        assert class_b.description is None
+
 
 class TestSlotGenerator:
     def test_instantiation(self):


### PR DESCRIPTION
## Summary

- Sets the `description` field on generated `ClassDefinition` objects from the
  Pydantic model's docstring (using the existing `normalize_whitespace` helper),
  mirroring the behavior already in place for enum translations.
- Models without a docstring produce `description=None` (unset).
- Adds a docstring to `mock_module0.A` and a focused test in
  `TestLinkmlGenerator` to cover both cases.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py::TestLinkmlGenerator::test_class_description_from_docstring -v`
- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py -v` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #30