### PR TITLE
feat: enhance `_union_schema` to support unions of all types handled by `SlotGenerator`

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -72,6 +72,12 @@ ANY_CLASS_DEF = ClassDefinition(
     name="Any", description="Any object", class_uri="linkml:Any"
 )
 
+# Fields of `SlotDefinition` excluded when projecting onto an
+# `AnonymousSlotExpression`. `required` is a slot-level property (whether the
+# slot must be present in an instance) and does not belong in a constraint
+# expression context.
+_ASE_EXCLUDED_SD_FIELDS = frozenset(["required"])
+
 
 class LinkmlGenerator:
     """
@@ -479,6 +485,27 @@ class SlotGenerator:
         :param note: The note to attach
         """
         self._slot.notes.append(f"{__package__}: {note}")
+
+    def _get_ase(self, subschema: core_schema.CoreSchema) -> AnonymousSlotExpression:
+        """
+        Get an `AnonymousSlotExpression` representing a given subschema
+
+        :param subschema: The given subschema. E.g., the schema of a choice in a
+            `core_schema.UnionSchema` which represents a union type in the type
+            annotation of the associated Pydantic model field
+        :return: An `AnonymousSlotExpression` representing the given subschema
+        """
+        sub_field_schema = self._field_schema._replace(schema=subschema)
+        sd = SlotGenerator(sub_field_schema).generate()
+
+        ase_kwargs = {
+            f.name: getattr(sd, f.name)
+            for f in fields(AnonymousSlotExpression)
+            if f.name not in _ASE_EXCLUDED_SD_FIELDS
+        }
+        return AnonymousSlotExpression(**ase_kwargs)
+
+
 
     if pydantic_version >= version.parse("2.10"):
 
@@ -1104,23 +1131,6 @@ class SlotGenerator:
 
         :param schema: The schema representing the union restriction
         """
-        # TODO: the current implementation doesn't address all cases of `Union` partly
-        #   due to limitation of LinkML. Useful information
-        #   can be found at, https://github.com/orgs/linkml/discussions/2154
-
-        def get_model_slot_expression(
-            schema_: core_schema.CoreSchema,
-        ) -> AnonymousSlotExpression:
-            return AnonymousSlotExpression(
-                range=schema_["cls"].__name__,
-            )
-
-        # A map of supported type choices to the functions for generating the
-        # corresponding slot expression
-        supported_type_choices: dict[
-            str, Callable[[core_schema.CoreSchema], AnonymousSlotExpression]
-        ] = {"model": get_model_slot_expression}
-
         choices = schema["choices"]
 
         choice_slot_expressions = []
@@ -1134,17 +1144,7 @@ class SlotGenerator:
                 )
                 return
 
-            # Exits early if a choice is of unsupported type
-            c_type = c["type"]
-            if c_type not in supported_type_choices:
-                self._attach_note(
-                    f"Warning: The translation is incomplete. The union core schema "
-                    f"contains a choice of type {c_type}. The choice type is yet to be "
-                    f"supported. (core schema: {schema})."
-                )
-                return
-
-            choice_slot_expressions.append(supported_type_choices[c_type](c))
+            choice_slot_expressions.append(self._get_ase(c))
 
         self._slot.any_of = choice_slot_expressions
 

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -908,12 +908,12 @@ class TestSlotGenerator:
 
         slot = translate_field_to_slot(Foo1, "x")
 
-        assert slot.range is None
-        assert in_exactly_one_string(
-            "The union core schema contains a choice of type int. "
-            "The choice type is yet to be supported.",
-            slot.notes,
-        )
+        assert slot.range == ANY_CLASS_DEF.name
+        assert slot.any_of == [
+            AnonymousSlotExpression(range="integer"),
+            AnonymousSlotExpression(range="Bar1"),
+            AnonymousSlotExpression(range="string"),
+        ]
 
         # === Unions of two models ===
         class Foo2(BaseModel):
@@ -924,6 +924,20 @@ class TestSlotGenerator:
         assert slot.range == ANY_CLASS_DEF.name
         assert slot.any_of == [
             AnonymousSlotExpression(range="Bar1"),
+            AnonymousSlotExpression(range="Bar2"),
+        ]
+
+        # === Union of base types, lists, and models ===
+        class Foo3(BaseModel):
+            x: Union[int, list[Bar1], list[str], Bar2]
+
+        slot = translate_field_to_slot(Foo3, "x")
+
+        assert slot.range == ANY_CLASS_DEF.name
+        assert slot.any_of == [
+            AnonymousSlotExpression(range="integer"),
+            AnonymousSlotExpression(range="Bar1", multivalued=True),
+            AnonymousSlotExpression(range="string", multivalued=True),
             AnonymousSlotExpression(range="Bar2"),
         ]
 


### PR DESCRIPTION
## Summary

- Implements `_get_ase`, which converts a subschema to an `AnonymousSlotExpression` by delegating to a sub-`SlotGenerator` and projecting the resulting `SlotDefinition` fields (excluding `required`, a slot-level property that doesn't belong in a constraint expression context)
- Refactors `_union_schema` to use `_get_ase` instead of a hardcoded `supported_type_choices` dispatch, enabling union support for any type already handled by `SlotGenerator` (primitives, lists, models, etc.)
- Updates `test_union_schema`: the `Foo1` (`Union[int, Bar1, str]`) sub-case now asserts a correct `any_of` instead of an "unsupported" note; adds a `Foo3` (`Union[int, list[Bar1], list[str], Bar2]`) sub-case

Closes #37

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py::TestSlotGenerator::test_union_schema -v`
- [x] `hatch run test.py3.10:pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)