### PR TITLE
test: improve assertions in test_union_schema

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -505,8 +505,6 @@ class SlotGenerator:
         }
         return AnonymousSlotExpression(**ase_kwargs)
 
-
-
     if pydantic_version >= version.parse("2.10"):
 
         def _invalid_schema(self, schema: core_schema.InvalidSchema) -> None:

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -895,7 +895,12 @@ class TestSlotGenerator:
         ]
         slot = SlotGenerator(field_schema).generate()
 
-        assert slot.range is None
+        # `notes=slot.notes` is used instead of `notes=ANY` because
+        # `SlotDefinition.__eq__` serializes fields before comparing, which
+        # causes `unittest.mock.ANY` to be treated as the literal string
+        # `'<ANY>'` rather than a wildcard. The note content is checked
+        # separately below.
+        assert slot == SlotDefinition(name="x", required=True, notes=slot.notes)
         assert in_exactly_one_string(
             "The union core schema contains a tuple as a choice. "
             "Tuples as choices are yet to be supported.",
@@ -906,40 +911,46 @@ class TestSlotGenerator:
         class Foo1(BaseModel):
             x: Union[int, Bar1, str]
 
-        slot = translate_field_to_slot(Foo1, "x")
-
-        assert slot.range == ANY_CLASS_DEF.name
-        assert slot.any_of == [
-            AnonymousSlotExpression(range="integer"),
-            AnonymousSlotExpression(range="Bar1"),
-            AnonymousSlotExpression(range="string"),
-        ]
+        assert translate_field_to_slot(Foo1, "x") == SlotDefinition(
+            name="x",
+            range=ANY_CLASS_DEF.name,
+            required=True,
+            any_of=[
+                AnonymousSlotExpression(range="integer"),
+                AnonymousSlotExpression(range="Bar1"),
+                AnonymousSlotExpression(range="string"),
+            ],
+        )
 
         # === Unions of two models ===
         class Foo2(BaseModel):
             x: Union[Bar1, Bar2]
 
-        slot = translate_field_to_slot(Foo2, "x")
-
-        assert slot.range == ANY_CLASS_DEF.name
-        assert slot.any_of == [
-            AnonymousSlotExpression(range="Bar1"),
-            AnonymousSlotExpression(range="Bar2"),
-        ]
+        assert translate_field_to_slot(Foo2, "x") == SlotDefinition(
+            name="x",
+            range=ANY_CLASS_DEF.name,
+            required=True,
+            any_of=[
+                AnonymousSlotExpression(range="Bar1"),
+                AnonymousSlotExpression(range="Bar2"),
+            ],
+        )
 
         # === Union of base types, lists, and models ===
         class Foo3(BaseModel):
             x: Union[int, list[Bar1], list[str], Bar2]
 
-        slot = translate_field_to_slot(Foo3, "x")
-
-        assert slot.range == ANY_CLASS_DEF.name
-        assert slot.any_of == [
-            AnonymousSlotExpression(range="integer"),
-            AnonymousSlotExpression(range="Bar1", multivalued=True),
-            AnonymousSlotExpression(range="string", multivalued=True),
-            AnonymousSlotExpression(range="Bar2"),
-        ]
+        assert translate_field_to_slot(Foo3, "x") == SlotDefinition(
+            name="x",
+            range=ANY_CLASS_DEF.name,
+            required=True,
+            any_of=[
+                AnonymousSlotExpression(range="integer"),
+                AnonymousSlotExpression(range="Bar1", multivalued=True),
+                AnonymousSlotExpression(range="string", multivalued=True),
+                AnonymousSlotExpression(range="Bar2"),
+            ],
+        )
 
         # === Nested unions ===
         class Foo4(BaseModel):


### PR DESCRIPTION
## Summary

- Adds a test sub-case for nested union types (`Union[int, Union[str, Bar1]]`),
  verifying that nested unions are flattened correctly.
- Updates all other sub-cases in `test_union_schema` to assert the full
  `SlotDefinition` via `==` rather than checking individual attributes, making
  assertions more complete and consistent with the new nested-union case.
- For the tuple-choice sub-case, `notes=slot.notes` is used in the
  `SlotDefinition` comparison (instead of `unittest.mock.ANY`) because
  `SlotDefinition.__eq__` serializes fields before comparing, which causes
  `ANY` to be treated as the literal string `'<ANY>'`. Note content is still
  verified separately with `in_exactly_one_string`.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py::TestSlotGenerator::test_union_schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)