### PR TITLE
Translate Pydantic field title and description to LinkML

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -457,6 +457,13 @@ class SlotGenerator:
         # Pydantic fields are required unless a default value is provided
         self._slot.required = True
 
+        # Set title and description from the Pydantic field metadata
+        field_info = self._field_schema.field_info
+        if field_info.title is not None:
+            self._slot.title = field_info.title
+        if field_info.description is not None:
+            self._slot.description = field_info.description
+
         # Shape the contained slot according to core schema of the corresponding field
         self._shape_slot(self._field_schema.schema)
 

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -1121,3 +1121,27 @@ class TestSlotGenerator:
 
         assert slot.range == "string"
         assert slot.pattern == expected_pattern
+
+    @pytest.mark.parametrize(
+        ("title", "description"),
+        [
+            ("My Title", "My description"),
+            ("My Title", None),
+            (None, "My description"),
+            (None, None),
+        ],
+    )
+    def test_title_and_description(self, title, description):
+        field_kwargs = {}
+        if title is not None:
+            field_kwargs["title"] = title
+        if description is not None:
+            field_kwargs["description"] = description
+
+        class Foo(BaseModel):
+            x: str = Field(**field_kwargs)
+
+        slot = translate_field_to_slot(Foo, "x")
+
+        assert slot.title == title
+        assert slot.description == description


### PR DESCRIPTION
## Summary

- Map `title` and `description` from Pydantic `FieldInfo` to the corresponding metadata slots on LinkML `SlotDefinition` in `SlotGenerator.generate()`
- Add parametrized test covering all combinations (both set, title only, description only, neither)

See https://github.com/dandi/dandi-schema/issues/394#issuecomment-4212031304 for context.

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Type check (`hatch run types:check`) — no new errors
- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py` — all 3488 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)