### PR TITLE
Fix leaking field-level properties into sub-schema translations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,10 @@ Options:
      resolved `pydantic_core.CoreSchema` objects for fields, distinguishing
      newly defined vs. overriding fields
    - `FieldSchema` (NamedTuple) — bundles a field's core schema, its
-     resolution context, field name, `FieldInfo`, and owning model
+     resolution context, field name, `FieldInfo`, owning model, and an
+     `is_subschema` flag (default `False`) indicating whether this
+     represents a sub-schema in the schema of a field (e.g., a union
+     choice) rather than the schema of the field itself
    - `resolve_ref_schema()` — resolves `definition-ref` and `definitions`
      schema types to concrete schemas
    - `canonicalize_schema_yml(yml)` — round-trips a YAML string through

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -72,12 +72,6 @@ ANY_CLASS_DEF = ClassDefinition(
     name="Any", description="Any object", class_uri="linkml:Any"
 )
 
-# Fields of `SlotDefinition` excluded when projecting onto an
-# `AnonymousSlotExpression`. `required` is a slot-level property (whether the
-# slot must be present in an instance) and does not belong in a constraint
-# expression context.
-_ASE_EXCLUDED_SD_FIELDS = frozenset(["required"])
-
 
 class LinkmlGenerator:
     """
@@ -453,16 +447,20 @@ class SlotGenerator:
         if self._used:
             raise GeneratorReuseError(self)
 
-        # Initialized the `required` meta slot to `True` since all
-        # Pydantic fields are required unless a default value is provided
-        self._slot.required = True
+        # Field-level properties (`required`, `title`, `description`) are only
+        # appropriate when translating the schema of the field itself, not a
+        # sub-schema in the schema of the field (e.g., a choice in a union type).
+        if not self._field_schema.is_subschema:
+            # Initialized the `required` meta slot to `True` since all
+            # Pydantic fields are required unless a default value is provided
+            self._slot.required = True
 
-        # Set title and description from the Pydantic field metadata
-        field_info = self._field_schema.field_info
-        if field_info.title is not None:
-            self._slot.title = field_info.title
-        if field_info.description is not None:
-            self._slot.description = field_info.description
+            # Set title and description from the Pydantic field metadata
+            field_info = self._field_schema.field_info
+            if field_info.title is not None:
+                self._slot.title = field_info.title
+            if field_info.description is not None:
+                self._slot.description = field_info.description
 
         # Shape the contained slot according to core schema of the corresponding field
         self._shape_slot(self._field_schema.schema)
@@ -505,13 +503,13 @@ class SlotGenerator:
             annotation of the associated Pydantic model field
         :return: An `AnonymousSlotExpression` representing the given subschema
         """
-        sub_field_schema = self._field_schema._replace(schema=subschema)
+        sub_field_schema = self._field_schema._replace(
+            schema=subschema, is_subschema=True
+        )
         sd = SlotGenerator(sub_field_schema).generate()
 
         ase_kwargs = {
-            f.name: getattr(sd, f.name)
-            for f in fields(AnonymousSlotExpression)
-            if f.name not in _ASE_EXCLUDED_SD_FIELDS
+            f.name: getattr(sd, f.name) for f in fields(AnonymousSlotExpression)
         }
         return AnonymousSlotExpression(**ase_kwargs)
 

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -57,6 +57,11 @@ class FieldSchema(NamedTuple):
     # The Pydantic model in which the field is defined
     model: type[BaseModel]
 
+    # Whether this represents a sub-schema in the schema of a field
+    # (e.g., a choice in a union type) rather than the schema of the
+    # field itself
+    is_subschema: bool = False
+
 
 class LocallyDefinedFields(NamedTuple):
     new: dict[str, FieldSchema]

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -1145,3 +1145,14 @@ class TestSlotGenerator:
 
         assert slot.title == title
         assert slot.description == description
+
+    def test_subschema_excludes_field_level_properties(self):
+        class Foo(BaseModel):
+            x: str = Field(title="T", description="D")
+
+        field_schema = get_field_schema(Foo, "x")._replace(is_subschema=True)
+        slot = SlotGenerator(field_schema).generate()
+
+        assert slot.required is None
+        assert slot.title is None
+        assert slot.description is None


### PR DESCRIPTION
## Summary

- Add `is_subschema` flag to `FieldSchema` to indicate when a schema represents a sub-schema in the schema of a field (e.g., a union choice) rather than the schema of the field itself
- Guard `required`, `title`, and `description` in `SlotGenerator.generate()` behind `not self._field_schema.is_subschema` so these field-level properties are never set for sub-schemas
- Remove `_ASE_EXCLUDED_SD_FIELDS` workaround that filtered `required` after the fact in `_get_ase()`

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Type check (`hatch run types:check`) — no new errors
- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py` — all 3489 pass
- [x] New test `test_subschema_excludes_field_level_properties` verifies `required`, `title`, and `description` remain unset for sub-schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)