### PR TITLE
refactor: allow non-constraint property overrides in slot_usage entries

### DIFF
--- a/src/pydantic2linkml/exceptions.py
+++ b/src/pydantic2linkml/exceptions.py
@@ -62,47 +62,49 @@ class SlotExtensionError(Exception):
     def __init__(
         self,
         missing_meta_slots: Optional[list[str]] = None,
-        varied_meta_slots: Optional[list[str]] = None,
+        varied_constraint_meta_slots: Optional[list[str]] = None,
     ):
         """
         :param missing_meta_slots: The meta slots that exist in the base slot definition
             but not in the target slot definition. If None or not provided, an empty
             list is used.
-        :param varied_meta_slots: The meta slots that exist in both the base and target
-            slot definitions but have different values. If None or not provided, an
-            empty list is used.
-        :raises ValueError: If both `missing_meta_slots` and `varied_meta_slots` are
-            empty
+        :param varied_constraint_meta_slots: The constraint meta slots (i.e., those
+            defined in ``SlotExpression``) that exist in both the base and target slot
+            definitions but have different values. If None or not provided, an empty
+            list is used.
+        :raises ValueError: If both `missing_meta_slots` and
+            `varied_constraint_meta_slots` are empty
         """
         if missing_meta_slots is None:
             missing_meta_slots = []
-        if varied_meta_slots is None:
-            varied_meta_slots = []
+        if varied_constraint_meta_slots is None:
+            varied_constraint_meta_slots = []
 
-        if len(missing_meta_slots) + len(varied_meta_slots) == 0:
+        if len(missing_meta_slots) + len(varied_constraint_meta_slots) == 0:
             error_msg = (
-                "At least one of `missing_meta_slots` and `varied_meta_slots` "
-                "must be non-empty."
+                "At least one of `missing_meta_slots` and "
+                "`varied_constraint_meta_slots` must be non-empty."
             )
             raise ValueError(error_msg)
 
         super().__init__()
 
         self.missing_meta_slots: list[str] = missing_meta_slots
-        self.varied_meta_slots: list[str] = varied_meta_slots
+        self.varied_constraint_meta_slots: list[str] = varied_constraint_meta_slots
 
     def __str__(self):
         return (
             f"Target slot definition has missing meta slots, "
-            f"{self.missing_meta_slots}, and varied meta slots, "
-            f"{self.varied_meta_slots}"
+            f"{self.missing_meta_slots}, and varied constraint meta slots, "
+            f"{self.varied_constraint_meta_slots}"
         )
 
     def __repr__(self):
         return (
             f"{type(self).__name__}"
             f"(missing_meta_slots={self.missing_meta_slots!r}, "
-            f"varied_meta_slots={self.varied_meta_slots!r})"
+            f"varied_constraint_meta_slots="
+            f"{self.varied_constraint_meta_slots!r})"
         )
 
 

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -303,10 +303,9 @@ class LinkmlGenerator:
             # Get the global slot representation of the field
             global_slot = self._sb.schema.slots[name]
 
-            if global_slot != new_field_slot_rep:
-                # Create a slot usage entry for the field
-                entry = get_slot_usage_entry(global_slot, new_field_slot_rep)
-                assert entry is not None
+            # Create a slot usage entry for the field
+            entry = get_slot_usage_entry(global_slot, new_field_slot_rep)
+            if entry is not None:
                 slot_usage.append(entry)
 
         # === Handle overriding fields in the model ===
@@ -343,8 +342,9 @@ class LinkmlGenerator:
                     else ""
                 )
                 varied_substr = (
-                    f"has changes in value in meta slots: {e.varied_meta_slots} "
-                    if e.varied_meta_slots
+                    f"has changes in value in constraint meta slots: "
+                    f"{e.varied_constraint_meta_slots} "
+                    if e.varied_constraint_meta_slots
                     else ""
                 )
                 substr = "and ".join(s for s in [missing_substr, varied_substr] if s)

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -16,6 +16,7 @@ from typing import Any, NamedTuple, Optional, TypeVar, cast
 import yaml
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition, SlotDefinition
+from linkml_runtime.linkml_model.meta import SlotExpression
 from linkml_runtime.loaders import yaml_loader
 from linkml_runtime.utils.formatutils import is_empty
 from pydantic import BaseModel, FilePath, RootModel, validate_call
@@ -33,6 +34,12 @@ from pydantic2linkml.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The set of field names defined in SlotExpression. These represent constraint
+# properties that cannot be overridden in a slot_usage entry.
+SLOT_EXPRESSION_FIELD_NAMES: frozenset[str] = frozenset(
+    f.name for f in fields(SlotExpression)
+)
 
 
 class StrEnum(str, Enum):
@@ -500,22 +507,39 @@ def get_slot_usage_entry(
     base: SlotDefinition, target: SlotDefinition
 ) -> Optional[SlotDefinition]:
     """
-    Obtain a slot usage entry that extends (refines) the base slot definition,
-    in a class definition, to achieve the behavior of the target slot definition
+    Obtain a slot usage entry that extends or overrides aspects of the base
+    slot definition, in a class definition, to achieve the behavior of the
+    target slot definition
+
+    In LinkML, ``slot_usage`` entries can extend the base slot with new
+    properties and override non-constraint properties (e.g., ``title``,
+    ``description``), but cannot override constraint properties (those
+    defined in ``SlotExpression``, such as ``range``, ``required``,
+    ``multivalued``, etc.).
 
     :param base: The base slot definition
-    :param target: The target slot definition
+    :param target: The target slot definition. Must have the same ``name`` as
+        *base*.
 
-    :return: The slot usage entry that extends the base slot definition to achieve the
-        behavior of the target slot definition. If the base slot definition doesn't
-        need an extension to achieve the behavior of the target slot definition, i.e.,
-        the base slot definition and the target slot definition are identical, `None` is
-        returned.
+    :return: The slot usage entry that extends or overrides aspects of the
+        base slot definition to achieve the behavior of the target slot
+        definition. If the base slot definition doesn't need any extension
+        or overriding to achieve the behavior of the target slot definition,
+        i.e., the base slot definition and the target slot definition are
+        identical from a slot_usage perspective, ``None`` is returned.
 
-    :raises SlotExtensionError: If the given base slot definition cannot be extended to
-        achieve the behavior of the given target slot definition through a slot usage
-        entry in a class definition
+    :raises ValueError: If ``base.name`` and ``target.name`` differ
+    :raises SlotExtensionError: If the given base slot definition cannot be
+        extended or overridden to achieve the behavior of the given target
+        slot definition through a slot usage entry in a class definition,
+        due to missing properties or differing constraint properties
     """
+    if base.name != target.name:
+        raise ValueError(
+            f"base and target must have the same name, "
+            f"got {base.name!r} and {target.name!r}"
+        )
+
     base_properties = get_non_empty_meta_slots(base)
     target_properties = get_non_empty_meta_slots(target)
 
@@ -527,20 +551,28 @@ def get_slot_usage_entry(
         if getattr(base, p) != getattr(target, p):
             varied_properties.add(p)
 
-    if missing_properties or varied_properties:
+    # Split varied properties into constraint (disqualifying) and
+    # non-constraint (overridable in slot_usage)
+    constraint_varied = varied_properties & SLOT_EXPRESSION_FIELD_NAMES
+    overridable_varied = varied_properties - SLOT_EXPRESSION_FIELD_NAMES
+
+    if missing_properties or constraint_varied:
         raise SlotExtensionError(
             missing_meta_slots=sorted(missing_properties, key=str.casefold),
-            varied_meta_slots=sorted(varied_properties, key=str.casefold),
+            varied_constraint_meta_slots=sorted(constraint_varied, key=str.casefold),
         )
 
     extended_properties = target_properties - base_properties
+    properties_for_slot_usage = extended_properties | overridable_varied
 
-    if not extended_properties:
+    if not properties_for_slot_usage:
         return None
 
-    # Note: A `name` argument is provided because the `SlotDefinition` class requires it
+    # Note: A `name` argument is provided because the `SlotDefinition`
+    # class requires it
     return SlotDefinition(
-        name=base.name, **{p: getattr(target, p) for p in extended_properties}
+        name=base.name,
+        **{p: getattr(target, p) for p in properties_for_slot_usage},
     )
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -583,71 +583,118 @@ def test_get_non_empty_meta_slots(slot, expected_non_empty_meta_slots):
     assert get_non_empty_meta_slots(slot) == expected_non_empty_meta_slots
 
 
-@pytest.mark.parametrize(
-    ("base", "target", "expected_missing", "expected_varied", "expected_return"),
-    [
-        # Base and target are the same
-        (SlotDefinition("a"), SlotDefinition("a"), [], [], None),
-        (
-            SlotDefinition("a", required=True, range="integer"),
-            SlotDefinition("a", required=True, range="integer"),
-            [],
-            [],
-            None,
-        ),
-        # Target is missing some required meta slots
-        (
-            SlotDefinition("a", required=True, range="integer"),
-            SlotDefinition("a"),
-            ["range", "required"],
-            [],
-            None,
-        ),
-        # Values in some meta slots in target are varied
-        (SlotDefinition("a"), SlotDefinition("b"), [], ["name"], None),
-        # Target is missing some required meta slots, and values in some meta slots in
-        # target are varied
-        (
-            SlotDefinition("a", required=True, range="integer"),
-            SlotDefinition("b"),
-            ["range", "required"],
-            ["name"],
-            None,
-        ),
-        # Target extends base
-        (
-            SlotDefinition("a", range="integer"),
-            SlotDefinition(
-                "a",
-                range="integer",
-                required=True,
-                multivalued=False,
-                mixins=["b"],
-                description="Hello, world!",
+class TestGetSlotUsageEntry:
+    @pytest.mark.parametrize(
+        ("base", "target"),
+        [
+            (SlotDefinition("a"), SlotDefinition("b")),
+            (
+                SlotDefinition("c", required=True, range="integer"),
+                SlotDefinition("d"),
             ),
-            [],
-            [],
-            SlotDefinition(
-                "a",
-                required=True,
-                multivalued=False,
-                mixins=["b"],
-                description="Hello, world!",
-            ),
-        ),
-    ],
-)
-def test_get_slot_usage_entry(
-    base, target, expected_missing, expected_varied, expected_return
-):
-    if expected_missing or expected_varied:
-        with pytest.raises(SlotExtensionError) as exc_info:
+        ],
+    )
+    def test_name_mismatch(self, base, target):
+        with pytest.raises(ValueError, match="must have the same name"):
             get_slot_usage_entry(base, target)
-        error = exc_info.value
-        assert error.missing_meta_slots == expected_missing
-        assert error.varied_meta_slots == expected_varied
-    else:
-        assert get_slot_usage_entry(base, target) == expected_return
+
+    @pytest.mark.parametrize(
+        (
+            "base",
+            "target",
+            "expected_missing",
+            "expected_constraint_varied",
+            "expected_return",
+        ),
+        [
+            # Base and target are the same
+            (SlotDefinition("a"), SlotDefinition("a"), [], [], None),
+            (
+                SlotDefinition("a", required=True, range="integer"),
+                SlotDefinition("a", required=True, range="integer"),
+                [],
+                [],
+                None,
+            ),
+            # Target is missing some required meta slots
+            (
+                SlotDefinition("a", required=True, range="integer"),
+                SlotDefinition("a"),
+                ["range", "required"],
+                [],
+                None,
+            ),
+            # Target extends base
+            (
+                SlotDefinition("a", range="integer"),
+                SlotDefinition(
+                    "a",
+                    range="integer",
+                    required=True,
+                    multivalued=False,
+                    mixins=["b"],
+                    description="Hello, world!",
+                ),
+                [],
+                [],
+                SlotDefinition(
+                    "a",
+                    required=True,
+                    multivalued=False,
+                    mixins=["b"],
+                    description="Hello, world!",
+                ),
+            ),
+            # Non-constraint varied property succeeds
+            (
+                SlotDefinition("a", description="old"),
+                SlotDefinition("a", description="new"),
+                [],
+                [],
+                SlotDefinition("a", description="new"),
+            ),
+            # Mixed non-constraint varied + extended properties
+            (
+                SlotDefinition("a", title="T1"),
+                SlotDefinition("a", title="T2", required=True),
+                [],
+                [],
+                SlotDefinition("a", title="T2", required=True),
+            ),
+            # Constraint varied property still raises
+            (
+                SlotDefinition("a", range="integer"),
+                SlotDefinition("a", range="string"),
+                [],
+                ["range"],
+                None,
+            ),
+            # Mixed constraint + non-constraint varied: only constraint reported
+            (
+                SlotDefinition("a", range="integer", description="old"),
+                SlotDefinition("a", range="string", description="new"),
+                [],
+                ["range"],
+                None,
+            ),
+        ],
+    )
+    def test_slot_usage_entry(
+        self,
+        base,
+        target,
+        expected_missing,
+        expected_constraint_varied,
+        expected_return,
+    ):
+        if expected_missing or expected_constraint_varied:
+            with pytest.raises(SlotExtensionError) as exc_info:
+                get_slot_usage_entry(base, target)
+            error = exc_info.value
+            assert error.missing_meta_slots == expected_missing
+            assert error.varied_constraint_meta_slots == expected_constraint_varied
+        else:
+            assert get_slot_usage_entry(base, target) == expected_return
 
 
 class TestCanonicalizeSchemaYml:


### PR DESCRIPTION
## Summary

- Only `SlotExpression` (constraint) properties now disqualify `get_slot_usage_entry` from producing a `slot_usage` entry. Non-constraint properties like `title` and `description` can be overridden and are included in the returned `SlotDefinition`.
- Add `SLOT_EXPRESSION_FIELD_NAMES` constant and split varied properties into constraint vs overridable in `get_slot_usage_entry`; add a name-equality precondition (`ValueError` if names differ).
- Rename `SlotExtensionError.varied_meta_slots` to `varied_constraint_meta_slots` for clarity.
- Simplify newly-defined-fields block in `_generate_class`: remove redundant equality check and assertion in favor of a direct `get_slot_usage_entry` call with `None` check.
- Update note text in `gen_linkml.py` to mention "constraint meta slots".
- Group `get_slot_usage_entry` tests into `TestGetSlotUsageEntry` class and add cases for non-constraint varied properties.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_tools.py -v` — all 139 tests pass
- [x] `hatch run test.py3.10:pytest tests/ -v` — all 3640 tests pass
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — 14 files already formatted
- [x] `hatch run types:check` — 28 errors, all pre-existing (untyped linkml stubs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)