### PR TITLE
Emit concise LinkML for single-type `LiteralSchema`

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -905,7 +905,31 @@ class SlotGenerator:
                 f"`{expected}`. LinkML has direct support for only string "
                 f"and integer elements in expressing such a restriction."
             )
+        elif len(literal_types) == 1:
+            # All literals are of the same type, which is either `str` or `int`
+            literal_type = literal_types.pop()
+
+            if literal_type is str:
+                range_ = "string"
+                equals_attr = "equals_string"
+            else:
+                range_ = "integer"
+                equals_attr = "equals_number"
+
+            self._slot.range = range_
+
+            if len(expected) == 1:
+                # There is only one literal
+                literal = expected[0]
+                setattr(self._slot, equals_attr, literal)
+            else:
+                # There are multiple literals
+                self._slot.any_of = [
+                    AnonymousSlotExpression(**{equals_attr: literal})
+                    for literal in expected
+                ]
         else:
+            # The literals are of different types, which are `str` and `int`.
             self._slot.range = "Any"
             self._slot.any_of = [
                 (

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -608,31 +608,67 @@ class TestSlotGenerator:
             )
 
     @pytest.mark.parametrize(
-        ("literal_specs", "are_literals_supported", "any_of_slot_value"),
+        ("literal_specs", "are_literals_supported", "expected_slot_attrs"),
         [
-            (
-                Literal[4, "hello", 1, "you"],
-                True,
-                [
-                    AnonymousSlotExpression(range="integer", equals_number=4),
-                    AnonymousSlotExpression(range="string", equals_string="hello"),
-                    AnonymousSlotExpression(range="integer", equals_number=1),
-                    AnonymousSlotExpression(range="string", equals_string="you"),
-                ],
-            ),
+            # Single string literal
             (
                 Literal["hello"],
                 True,
-                [
-                    AnonymousSlotExpression(range="string", equals_string="hello"),
-                ],
+                {"range": "string", "equals_string": "hello"},
             ),
+            # Single integer literal
+            (
+                Literal[42],
+                True,
+                {"range": "integer", "equals_number": 42},
+            ),
+            # Multiple string literals
+            (
+                Literal["hello", "world"],
+                True,
+                {
+                    "range": "string",
+                    "any_of": [
+                        AnonymousSlotExpression(equals_string="hello"),
+                        AnonymousSlotExpression(equals_string="world"),
+                    ],
+                },
+            ),
+            # Multiple integer literals
+            (
+                Literal[1, 2, 3],
+                True,
+                {
+                    "range": "integer",
+                    "any_of": [
+                        AnonymousSlotExpression(equals_number=1),
+                        AnonymousSlotExpression(equals_number=2),
+                        AnonymousSlotExpression(equals_number=3),
+                    ],
+                },
+            ),
+            # Mixed string and integer literals
+            (
+                Literal[4, "hello", 1, "you"],
+                True,
+                {
+                    "range": "Any",
+                    "any_of": [
+                        AnonymousSlotExpression(range="integer", equals_number=4),
+                        AnonymousSlotExpression(range="string", equals_string="hello"),
+                        AnonymousSlotExpression(range="integer", equals_number=1),
+                        AnonymousSlotExpression(range="string", equals_string="you"),
+                    ],
+                },
+            ),
+            # Unsupported: contains `None`
             (Literal[4, "hello", 1, None, "you"], False, None),
+            # Unsupported: `bool` literal
             (Literal[True], False, None),
         ],
     )
     def test_literal_schema(
-        self, literal_specs, are_literals_supported, any_of_slot_value
+        self, literal_specs, are_literals_supported, expected_slot_attrs
     ):
 
         class Foo(BaseModel):
@@ -647,8 +683,10 @@ class TestSlotGenerator:
         )
 
         if are_literals_supported:
-            assert slot.range == "Any"
-            assert slot.any_of == any_of_slot_value
+            assert slot.range == expected_slot_attrs["range"]
+            assert slot.equals_string == expected_slot_attrs.get("equals_string")
+            assert slot.equals_number == expected_slot_attrs.get("equals_number")
+            assert slot.any_of == expected_slot_attrs.get("any_of", [])
         else:
             # The `range` and `any_of` meta slots should be unset
             assert slot.range is None


### PR DESCRIPTION
## Summary

- When all members of a `Literal[...]` are of the same supported type
  (`str` or `int`), emit `range=string/integer` with `equals_string` or
  `equals_number` directly.
- Use `any_of` only when there is more than one literal; reserve
  `range=\"Any\"` with typed `any_of` entries for the mixed `str`/`int`
  case.
- Update `test_literal_schema` to cover single and multiple same-type
  literals for both `str` and `int`, alongside the existing mixed-type
  and unsupported cases.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py -k test_literal_schema -v`
- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py`
- [x] `ruff check .` and `ruff format --check .`
- [x] `hatch run types:check` (no new errors introduced)