### PR TITLE
refactor: rename `SlotExtensionError` to `SlotUsageGenerationError`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,10 @@ Options:
    - `NameCollisionError` — duplicate class/enum names across modules
    - `GeneratorReuseError` — attempting to reuse a single-use generator
    - `TranslationNotImplementedError` — schema type not yet handled
-   - `SlotExtensionError` — cannot extend a base slot to match a target
-     via slot_usage
+   - `SlotUsageGenerationError` — cannot generate a slot_usage entry to
+     make a base slot function like a target slot (a slot_usage entry can
+     only extend the base slot with new properties or override the base
+     slot's non-constraint properties)
    - `YAMLContentError` — YAML file content is not what is expected (e.g.,
      not a mapping)
    - `InvalidLinkMLSchemaError` — schema does not conform to the LinkML

--- a/src/pydantic2linkml/exceptions.py
+++ b/src/pydantic2linkml/exceptions.py
@@ -53,10 +53,13 @@ class TranslationNotImplementedError(NotImplementedError):
         )
 
 
-class SlotExtensionError(Exception):
+class SlotUsageGenerationError(Exception):
     """
-    Raise when a given base slot definition cannot be extended to achieve the behavior
-    of a given target slot definition through a slot usage entry in a class definition
+    Raise when a slot usage entry cannot be generated to make a given base slot
+    definition function like a given target slot definition. A slot usage entry can
+    only extend the base with new properties (meta slots) or override non-constraint
+    properties of the base; it cannot remove properties from the base nor override
+    its constraint properties (those defined in ``SlotExpression``).
     """
 
     def __init__(

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -33,7 +33,7 @@ from pydantic_core import core_schema
 
 from pydantic2linkml.exceptions import (
     GeneratorReuseError,
-    SlotExtensionError,
+    SlotUsageGenerationError,
     TranslationNotImplementedError,
 )
 from pydantic2linkml.tools import (
@@ -334,7 +334,7 @@ class LinkmlGenerator:
                 entry = get_slot_usage_entry(
                     overridden_field_slot_rep, overriding_field_slot_rep
                 )
-            except SlotExtensionError as e:
+            except SlotUsageGenerationError as e:
                 # Attach needed note
                 missing_substr = (
                     f"lacks meta slots: {e.missing_meta_slots} "

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -29,7 +29,7 @@ from pydantic_core import core_schema
 from pydantic2linkml.exceptions import (
     InvalidLinkMLSchemaError,
     NameCollisionError,
-    SlotExtensionError,
+    SlotUsageGenerationError,
     YAMLContentError,
 )
 
@@ -529,10 +529,13 @@ def get_slot_usage_entry(
         identical from a slot_usage perspective, ``None`` is returned.
 
     :raises ValueError: If ``base.name`` and ``target.name`` differ
-    :raises SlotExtensionError: If the given base slot definition cannot be
-        extended or overridden to achieve the behavior of the given target
-        slot definition through a slot usage entry in a class definition,
-        due to missing properties or differing constraint properties
+    :raises SlotUsageGenerationError: If a slot usage entry cannot be
+        generated to make the given base slot definition function like the
+        given target slot definition. A slot usage entry can only extend the
+        base with new properties (meta slots) or override non-constraint
+        properties of the base; it cannot remove properties from the base
+        nor override its constraint properties (those defined in
+        ``SlotExpression``).
     """
     if base.name != target.name:
         raise ValueError(
@@ -557,7 +560,7 @@ def get_slot_usage_entry(
     overridable_varied = varied_properties - SLOT_EXPRESSION_FIELD_NAMES
 
     if missing_properties or constraint_varied:
-        raise SlotExtensionError(
+        raise SlotUsageGenerationError(
             missing_meta_slots=sorted(missing_properties, key=str.casefold),
             varied_constraint_meta_slots=sorted(constraint_varied, key=str.casefold),
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,7 @@ from pydantic_core import core_schema
 from pydantic2linkml.exceptions import (
     InvalidLinkMLSchemaError,
     NameCollisionError,
-    SlotExtensionError,
+    SlotUsageGenerationError,
     YAMLContentError,
 )
 from pydantic2linkml.tools import (
@@ -688,7 +688,7 @@ class TestGetSlotUsageEntry:
         expected_return,
     ):
         if expected_missing or expected_constraint_varied:
-            with pytest.raises(SlotExtensionError) as exc_info:
+            with pytest.raises(SlotUsageGenerationError) as exc_info:
                 get_slot_usage_entry(base, target)
             error = exc_info.value
             assert error.missing_meta_slots == expected_missing


### PR DESCRIPTION
## Summary

- Rename `SlotExtensionError` to `SlotUsageGenerationError`. The exception
  is raised when `get_slot_usage_entry()` cannot generate a slot_usage
  entry to make a base slot function like a target slot — not only in the
  "extension" case (base has properties missing from the target) but also
  in the constraint-mismatch case. The new name reflects the operation
  (generating a slot_usage entry) rather than one of the two failure modes.
- Clarify the class docstring, the `:raises:` docstring of
  `get_slot_usage_entry()`, and the `CLAUDE.md` exceptions listing to
  state that a slot_usage entry can only extend the base with new
  properties or override the base's non-constraint properties.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `hatch run test.py3.10:pytest tests/test_tools.py` (139 passed)
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)