### PR TITLE
Express string length constraints via `all_of` pattern entry

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -680,44 +680,21 @@ class SlotGenerator:
         max_length: Optional[int] = schema.get("max_length")
         min_length: Optional[int] = schema.get("min_length")
 
-        if max_length is not None:
-            self._attach_note(
-                "LinkML does not have direct support for max length constraints. "
-                f"The max length constraint of {max_length} is incorporated "
-                "into the pattern of the slot."
-            )
-
-        if min_length is not None:
-            self._attach_note(
-                "LinkML does not have direct support for min length constraints. "
-                f"The min length constraint of {min_length} is incorporated "
-                "into the pattern of the slot."
-            )
-
-        # == Incorporate any length constraints into the pattern of the slot ==
+        # == Express any length constraint as a pattern in the slot's `all_of` ==
+        # [\s\S] admits newlines (Pydantic counts them); \Z anchors to the true
+        # end of the string (unlike `$`, which also matches before a trailing
+        # newline under Python's `re`).
         if max_length is not None or min_length is not None:
-            length_constraint_regex = (
-                f"^(?=."
-                f"{{{min_length if min_length is not None else ''},"
-                f"{max_length if max_length is not None else ''}}}$)"
+            lo = min_length if min_length is not None else ""
+            hi = max_length if max_length is not None else ""
+            self._slot.all_of.append(
+                AnonymousSlotExpression(pattern=rf"^[\s\S]{{{lo},{hi}}}\Z")
             )
-
-            orig_ptrn = self._slot.pattern
-            if orig_ptrn is not None:
-                # == There is an existing pattern carried over
-                # from the Pydantic core schema ==
-
-                # Update the pattern to include the length constraint
-                self._slot.pattern = (
-                    f"{length_constraint_regex}"
-                    f"{orig_ptrn[1:] if orig_ptrn.startswith('^') else orig_ptrn}"
-                )
-            else:
-                # == There is no existing pattern carried over
-                # from the Pydantic core schema ==
-
-                # Set the pattern to the length constraint
-                self._slot.pattern = length_constraint_regex
+            self._attach_note(
+                f"Length constraint of min_length={min_length}, "
+                f"max_length={max_length} expressed as a pattern entry in the "
+                "slot's `all_of`."
+            )
 
         if schema.get("strip_whitespace"):
             self._attach_note(
@@ -1299,17 +1276,22 @@ class SlotGenerator:
 
         self._slot.range = "uri"
 
-        # Incorporate `max_length` and `allowed_schemes` restrictions into the pattern
-        # meta slot
+        # Express `allowed_schemes` restriction in the pattern meta slot
         max_length: Optional[int] = schema.get("max_length")
         allowed_schemes: Optional[list[str]] = schema.get("allowed_schemes")
-        max_length_re = rf"(?=.{{,{max_length}}}$)" if max_length is not None else ""
         allowed_schemes_re = (
             rf"(?i:{'|'.join(re.escape(scheme) for scheme in allowed_schemes)})"
             if allowed_schemes is not None
             else r"[^\s]+"
         )
-        self._slot.pattern = rf"^{max_length_re}{allowed_schemes_re}://[^\s]+$"
+        self._slot.pattern = rf"^{allowed_schemes_re}://[^\s]+$"
+
+        # Express any `max_length` restriction as a pattern entry in `all_of`.
+        # [\s\S] admits newlines; \Z anchors to the true end of the string.
+        if max_length is not None:
+            self._slot.all_of.append(
+                AnonymousSlotExpression(pattern=rf"^[\s\S]{{,{max_length}}}\Z")
+            )
 
         if "host_required" in schema:
             self._attach_note("Unable to express the `host_required` option in LinkML.")

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -362,19 +362,19 @@ class TestSlotGenerator:
         verify_notes(f"greater than {gt}", gt is not None)
 
     @pytest.mark.parametrize(
-        ("pattern", "max_length", "min_length", "output_pattern"),
+        ("pattern", "max_length", "min_length", "expected_all_of_pattern"),
         [
-            (None, 10, 4, r"^(?=.{4,10}$)"),
-            (None, None, 4, r"^(?=.{4,}$)"),
-            (None, 10, None, r"^(?=.{,10}$)"),
-            (r"^[a-zA-Z0-9]+", 3, 2, r"^(?=.{2,3}$)[a-zA-Z0-9]+"),
-            (r"^[a-zA-Z0-9]+", None, 2, r"^(?=.{2,}$)[a-zA-Z0-9]+"),
-            (r"^[a-zA-Z0-9]+", 3, None, r"^(?=.{,3}$)[a-zA-Z0-9]+"),
-            (ptrn := r"^[a-zA-Z0-9]+", None, None, ptrn),
-            (r".*", 10, 4, r"^(?=.{4,10}$).*"),
-            (r".*", None, 4, r"^(?=.{4,}$).*"),
-            (r".*", 10, None, r"^(?=.{,10}$).*"),
-            (ptrn := r".*", None, None, ptrn),
+            (None, 10, 4, r"^[\s\S]{4,10}\Z"),
+            (None, None, 4, r"^[\s\S]{4,}\Z"),
+            (None, 10, None, r"^[\s\S]{,10}\Z"),
+            (r"^[a-zA-Z0-9]+", 3, 2, r"^[\s\S]{2,3}\Z"),
+            (r"^[a-zA-Z0-9]+", None, 2, r"^[\s\S]{2,}\Z"),
+            (r"^[a-zA-Z0-9]+", 3, None, r"^[\s\S]{,3}\Z"),
+            (r"^[a-zA-Z0-9]+", None, None, None),
+            (r".*", 10, 4, r"^[\s\S]{4,10}\Z"),
+            (r".*", None, 4, r"^[\s\S]{4,}\Z"),
+            (r".*", 10, None, r"^[\s\S]{,10}\Z"),
+            (r".*", None, None, None),
             (None, None, None, None),
         ],
     )
@@ -389,7 +389,7 @@ class TestSlotGenerator:
         strip_whitespace,
         to_lower,
         to_upper,
-        output_pattern,
+        expected_all_of_pattern,
     ):
         class Foo(BaseModel):
             # noinspection PyTypeHints
@@ -409,14 +409,19 @@ class TestSlotGenerator:
         verify_notes = partial(verify_str_lst, str_lst=slot.notes)
 
         assert slot.range == "string"
-        assert slot.pattern == output_pattern
+        # The Pydantic-supplied pattern (if any) is carried over untouched.
+        assert slot.pattern == pattern
+        if expected_all_of_pattern is None:
+            assert slot.all_of == []
+        else:
+            assert slot.all_of == [
+                AnonymousSlotExpression(pattern=expected_all_of_pattern)
+            ]
         verify_notes(
-            f"The max length constraint of {max_length} is incorporated",
-            max_length is not None,
-        )
-        verify_notes(
-            f"The min length constraint of {min_length} is incorporated",
-            min_length is not None,
+            "Length constraint of "
+            f"min_length={min_length}, max_length={max_length} "
+            "expressed as a pattern entry in the slot's `all_of`",
+            max_length is not None or min_length is not None,
         )
         verify_notes(
             "stripping leading and trailing whitespace in LinkML",
@@ -1087,10 +1092,10 @@ class TestSlotGenerator:
     @pytest.mark.parametrize(
         ("max_length", "allowed_schemes", "expected_pattern"),
         [
-            (100, ["http", "https"], r"^(?=.{,100}$)(?i:http|https)://[^\s]+$"),
-            (42, ["http"], r"^(?=.{,42}$)(?i:http)://[^\s]+$"),
+            (100, ["http", "https"], r"^(?i:http|https)://[^\s]+$"),
+            (42, ["http"], r"^(?i:http)://[^\s]+$"),
             (None, ["http", "https"], r"^(?i:http|https)://[^\s]+$"),
-            (50, None, r"^(?=.{,50}$)[^\s]+://[^\s]+$"),
+            (50, None, r"^[^\s]+://[^\s]+$"),
             (None, None, r"^[^\s]+://[^\s]+$"),
         ],
     )
@@ -1126,6 +1131,12 @@ class TestSlotGenerator:
 
         assert slot.range == "uri"
         assert slot.pattern == expected_pattern
+        if max_length is None:
+            assert slot.all_of == []
+        else:
+            assert slot.all_of == [
+                AnonymousSlotExpression(pattern=rf"^[\s\S]{{,{max_length}}}\Z")
+            ]
         verify_notes(
             "Unable to express the `host_required` option in LinkML.",
             host_required is not None,


### PR DESCRIPTION
## Summary

- Translate Pydantic `StringSchema.min_length`/`max_length` and `UrlSchema.max_length` as a pattern inside the slot's `all_of` meta slot, instead of splicing a regex lookahead into the slot's `pattern`.
- Carry the Pydantic-supplied `pattern` over untouched.
- Use `^[\s\S]{min,max}\Z` for the length pattern so newlines count toward the length (matching Pydantic's `len(s)` semantics) and `\Z` forbids the trailing-newline bypass that `$` permits under Python's `re`.

## Why

The previous approach had two concrete bugs:

1. **Multi-line rejection.** `.` does not match `\n` under Python's `re` (which the LinkML validator uses). Pydantic counts all characters including newlines, so any multi-line string that Pydantic accepts was rejected by the translated schema.
2. **Brittle pattern splicing.** Stripping a leading `^` from the Pydantic pattern to prepend the lookahead silently mangles patterns that start with flags like `(?i)`, a group, or `\A`, and breaks alternation — `foo|bar` would become `(?=...)foo|bar`, binding the lookahead only to the left arm.

`all_of` keeps the user-authored `pattern` and the synthesized length pattern independently, so neither can interfere with the other.

## Test plan

- [x] `hatch -e test.py3.10 run pytest tests/test_gen_linkml.py -k "str_schema or url_schema"` — 444 passed
- [x] `hatch -e test.py3.10 run pytest tests/` — 3492 passed, 14 xfailed (pre-existing)
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] `hatch run types:check` — 24 pre-existing mypy errors, 2 fewer than HEAD, zero new
- [x] End-to-end: hand-written LinkML schema with `pattern` + `all_of` pattern validated against multi-line instances via `linkml-validate` (see `scratch/allof_test/`)