### PR TITLE
refactor: replace hardcoding of `Any` range value

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -907,7 +907,7 @@ class SlotGenerator:
                 ]
         else:
             # The literals are of different types, which are `str` and `int`.
-            self._slot.range = "Any"
+            self._slot.range = ANY_CLASS_DEF.name
             self._slot.any_of = [
                 (
                     AnonymousSlotExpression(equals_string=literal, range="string")


### PR DESCRIPTION
## Summary
- Replace the remaining hardcoded `"Any"` range string in `SlotGenerator` with `ANY_CLASS_DEF.name`, matching the other three call sites.

## Test plan
- [x] `ruff check .`
- [x] `hatch run test.py3.10:pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)