### PR TITLE
Allow `required: False -> True` refinement in slot_usage entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,11 +128,20 @@ Options:
    - `GeneratorReuseError` — attempting to reuse a single-use generator
    - `TranslationNotImplementedError` — schema type not yet handled
    - `SlotUsageGenerationError` — cannot generate a slot_usage entry to
-     make a base slot function like a target slot (a slot_usage entry can
-     only extend the base slot with new properties or override the base
-     slot's non-constraint properties); accepts any `Iterable[str]` for
-     its meta-slot lists and sorts them case-insensitively on
-     construction
+     make a base slot function like a target slot. A slot_usage entry can
+     extend the base slot with new properties, override the base slot's
+     non-constraint properties, and apply allowed monotonic refinements
+     to its constraint properties (those defined in `SlotExpression`).
+     The set of allowed refinements is defined by
+     `_is_allowed_constraint_refinement` in `tools.py`. Any other change
+     in a constraint property, or any meta slot missing from the target
+     that is present in the base, triggers this error. The error accepts
+     any `Iterable[str]` for its meta-slot lists (`missing_meta_slots`,
+     `disallowed_varied_constraint_meta_slots`) and sorts them
+     case-insensitively on construction. The "disallowed varied" framing
+     reflects that not every varied constraint meta slot is an error —
+     allowed monotonic refinements are emitted into the slot_usage entry
+     instead.
    - `YAMLContentError` — YAML file content is not what is expected (e.g.,
      not a mapping)
    - `InvalidLinkMLSchemaError` — schema does not conform to the LinkML

--- a/src/pydantic2linkml/exceptions.py
+++ b/src/pydantic2linkml/exceptions.py
@@ -57,16 +57,24 @@ class TranslationNotImplementedError(NotImplementedError):
 class SlotUsageGenerationError(Exception):
     """
     Raise when a slot usage entry cannot be generated to make a given base slot
-    definition function like a given target slot definition. A slot usage entry can
-    only extend the base with new properties (meta slots) or override non-constraint
-    properties of the base; it cannot remove properties from the base nor override
-    its constraint properties (those defined in ``SlotExpression``).
+    definition function like a given target slot definition.
+
+    A ``slot_usage`` entry can extend the base slot with new properties (meta
+    slots), override the base slot's non-constraint properties (e.g.,
+    ``title``, ``description``), and refine the base slot's constraint
+    properties (those defined in ``SlotExpression``) in ways that are
+    recognized as safe monotonic tightenings. The set of recognized
+    refinements is defined by ``_is_allowed_constraint_refinement`` in
+    ``pydantic2linkml.tools``. Any other change in a constraint property,
+    or any meta slot that exists in the base but not in the target, makes
+    the situation unrepresentable as a ``slot_usage`` entry and triggers
+    this error.
     """
 
     def __init__(
         self,
         missing_meta_slots: Optional[Iterable[str]] = None,
-        varied_constraint_meta_slots: Optional[Iterable[str]] = None,
+        disallowed_varied_constraint_meta_slots: Optional[Iterable[str]] = None,
     ):
         """
         :param missing_meta_slots: The input for setting
@@ -75,48 +83,58 @@ class SlotUsageGenerationError(Exception):
             are the meta slots that exist in the base slot definition but
             not in the target slot definition. If None or not provided,
             an empty list is used.
-        :param varied_constraint_meta_slots: The input for setting
-            ``self.varied_constraint_meta_slots``, which is a list of the
-            items provided in this input sorted case-insensitively. These
-            items are the constraint meta slots (i.e., those defined in
-            ``SlotExpression``) that exist in both the base and target
-            slot definitions but have different values. If None or not
-            provided, an empty list is used.
+        :param disallowed_varied_constraint_meta_slots: The input for
+            setting ``self.disallowed_varied_constraint_meta_slots``,
+            which is a list of the items provided in this input sorted
+            case-insensitively. These items are the constraint meta slots
+            (i.e., those defined in ``SlotExpression``) that exist in
+            both the base and target slot definitions, have different
+            values, and whose (base, target) change is not one of the
+            allowed monotonic refinements that can be safely emitted as a
+            ``slot_usage`` entry. (Constraint meta slots whose change
+            is an allowed refinement, as defined by
+            ``_is_allowed_constraint_refinement`` in
+            ``pydantic2linkml.tools``, do not appear here.) If None or
+            not provided, an empty list is used.
         :raises ValueError: If both `missing_meta_slots` and
-            `varied_constraint_meta_slots` are empty
+            `disallowed_varied_constraint_meta_slots` are empty
         """
 
         def _sort(items: Optional[Iterable[str]]) -> list[str]:
             return sorted(items, key=str.casefold) if items is not None else []
 
         sorted_missing: list[str] = _sort(missing_meta_slots)
-        sorted_constraint: list[str] = _sort(varied_constraint_meta_slots)
+        sorted_disallowed_varied_constraint: list[str] = _sort(
+            disallowed_varied_constraint_meta_slots
+        )
 
-        if len(sorted_missing) + len(sorted_constraint) == 0:
+        if len(sorted_missing) + len(sorted_disallowed_varied_constraint) == 0:
             error_msg = (
                 "At least one of `missing_meta_slots` and "
-                "`varied_constraint_meta_slots` must be non-empty."
+                "`disallowed_varied_constraint_meta_slots` must be non-empty."
             )
             raise ValueError(error_msg)
 
         super().__init__()
 
         self.missing_meta_slots: list[str] = sorted_missing
-        self.varied_constraint_meta_slots: list[str] = sorted_constraint
+        self.disallowed_varied_constraint_meta_slots: list[str] = (
+            sorted_disallowed_varied_constraint
+        )
 
     def __str__(self):
         return (
             f"Target slot definition has missing meta slots, "
-            f"{self.missing_meta_slots}, and varied constraint meta slots, "
-            f"{self.varied_constraint_meta_slots}"
+            f"{self.missing_meta_slots}, and disallowed varied constraint "
+            f"meta slots, {self.disallowed_varied_constraint_meta_slots}"
         )
 
     def __repr__(self):
         return (
             f"{type(self).__name__}"
             f"(missing_meta_slots={self.missing_meta_slots!r}, "
-            f"varied_constraint_meta_slots="
-            f"{self.varied_constraint_meta_slots!r})"
+            f"disallowed_varied_constraint_meta_slots="
+            f"{self.disallowed_varied_constraint_meta_slots!r})"
         )
 
 

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -342,9 +342,9 @@ class LinkmlGenerator:
                     else ""
                 )
                 varied_substr = (
-                    f"has changes in value in constraint meta slots: "
-                    f"{e.varied_constraint_meta_slots} "
-                    if e.varied_constraint_meta_slots
+                    f"has disallowed changes in value in constraint meta "
+                    f"slots: {e.disallowed_varied_constraint_meta_slots} "
+                    if e.disallowed_varied_constraint_meta_slots
                     else ""
                 )
                 substr = "and ".join(s for s in [missing_substr, varied_substr] if s)

--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -35,11 +35,42 @@ from pydantic2linkml.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-# The set of field names defined in SlotExpression. These represent constraint
-# properties that cannot be overridden in a slot_usage entry.
+# The set of field names defined in SlotExpression. These represent
+# constraint properties of a slot. A change in such a property between a base
+# slot and a target slot can only be expressed in a slot_usage entry when the
+# change is one of the allowed monotonic refinements; see
+# ``_is_allowed_constraint_refinement``.
 SLOT_EXPRESSION_FIELD_NAMES: frozenset[str] = frozenset(
     f.name for f in fields(SlotExpression)
 )
+
+
+def _is_allowed_constraint_refinement(
+    meta_slot: str, base_value: Any, target_value: Any
+) -> bool:
+    """
+    Decide whether a change in a constraint meta slot value from ``base_value``
+    to ``target_value`` is an allowed monotonic refinement that can be safely
+    emitted as part of a ``slot_usage`` entry.
+
+    LinkML schemas are intended to be monotonic — ``slot_usage`` should
+    *refine* (tighten) inherited constraints, not loosen or replace them.
+    The LinkML runtime does not currently enforce this (see
+    https://github.com/linkml/linkml/issues/1508), so this function
+    conservatively allows only a case that is an unambiguously safe
+    tightening.
+
+    Currently, the only allowed refinement is ``required`` going from
+    ``False`` to ``True``.
+
+    :param meta_slot: The name of the constraint meta slot
+    :param base_value: The value of ``meta_slot`` on the base slot
+    :param target_value: The value of ``meta_slot`` on the target slot
+    :return: ``True`` iff the change is an allowed monotonic refinement
+    """
+    if meta_slot == "required":
+        return base_value is False and target_value is True
+    return False
 
 
 class StrEnum(str, Enum):
@@ -512,10 +543,18 @@ def get_slot_usage_entry(
     target slot definition
 
     In LinkML, ``slot_usage`` entries can extend the base slot with new
-    properties and override non-constraint properties (e.g., ``title``,
-    ``description``), but cannot override constraint properties (those
-    defined in ``SlotExpression``, such as ``range``, ``required``,
-    ``multivalued``, etc.).
+    properties and override its non-constraint properties (e.g., ``title``,
+    ``description``). LinkML schemas are intended to be monotonic, meaning
+    a ``slot_usage`` entry should *refine* (tighten) the base slot's
+    constraint properties (those defined in ``SlotExpression``, such as
+    ``range``, ``required``, ``multivalued``, etc.) rather than loosen or
+    replace them. The LinkML runtime does not currently enforce
+    monotonicity (see https://github.com/linkml/linkml/issues/1508), so
+    this function conservatively allows only unambiguously safe monotonic
+    refinements of constraint properties. The set of allowed refinements
+    is determined by ``_is_allowed_constraint_refinement``. A change in a
+    constraint property that is not an allowed refinement triggers a
+    ``SlotUsageGenerationError``.
 
     :param base: The base slot definition
     :param target: The target slot definition. Must have the same ``name`` as
@@ -531,11 +570,12 @@ def get_slot_usage_entry(
     :raises ValueError: If ``base.name`` and ``target.name`` differ
     :raises SlotUsageGenerationError: If a slot usage entry cannot be
         generated to make the given base slot definition function like the
-        given target slot definition. A slot usage entry can only extend the
-        base with new properties (meta slots) or override non-constraint
-        properties of the base; it cannot remove properties from the base
-        nor override its constraint properties (those defined in
-        ``SlotExpression``).
+        given target slot definition. A slot usage entry can extend the
+        base with new properties (meta slots), override the base's
+        non-constraint properties, and apply allowed monotonic refinements
+        to the base's constraint properties (those defined in
+        ``SlotExpression``); it cannot remove properties from the base nor
+        change a constraint property in any other way.
     """
     if base.name != target.name:
         raise ValueError(
@@ -549,24 +589,36 @@ def get_slot_usage_entry(
     missing_properties = base_properties - target_properties
     common_properties = base_properties & target_properties
 
-    varied_properties = set()
+    varied_properties = set[str]()
     for p in common_properties:
         if getattr(base, p) != getattr(target, p):
             varied_properties.add(p)
 
-    # Split varied properties into constraint (disqualifying) and
-    # non-constraint (overridable in slot_usage)
+    # Split varied properties into constraint (subject to monotonicity rules)
+    # and non-constraint (freely overridable in slot_usage)
     constraint_varied = varied_properties & SLOT_EXPRESSION_FIELD_NAMES
     overridable_varied = varied_properties - SLOT_EXPRESSION_FIELD_NAMES
 
-    if missing_properties or constraint_varied:
+    # Among the constraint-varied properties, separate those whose
+    # (base, target) change is an allowed monotonic refinement from those
+    # that are not allowed.
+    allowed_refined = {
+        p
+        for p in constraint_varied
+        if _is_allowed_constraint_refinement(p, getattr(base, p), getattr(target, p))
+    }
+    disallowed_varied_constraint = constraint_varied - allowed_refined
+
+    if missing_properties or disallowed_varied_constraint:
         raise SlotUsageGenerationError(
             missing_meta_slots=missing_properties,
-            varied_constraint_meta_slots=constraint_varied,
+            disallowed_varied_constraint_meta_slots=disallowed_varied_constraint,
         )
 
     extended_properties = target_properties - base_properties
-    properties_for_slot_usage = extended_properties | overridable_varied
+    properties_for_slot_usage = (
+        extended_properties | overridable_varied | allowed_refined
+    )
 
     if not properties_for_slot_usage:
         return None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,7 +7,12 @@ class TestSlotUsageGenerationError:
     """Tests for SlotUsageGenerationError sorting behavior."""
 
     @pytest.mark.parametrize(
-        ("missing", "constraint", "expected_missing", "expected_constraint"),
+        (
+            "missing",
+            "disallowed",
+            "expected_missing",
+            "expected_disallowed",
+        ),
         [
             (["Zeta", "alpha", "Beta"], None, ["alpha", "Beta", "Zeta"], []),
             (None, ["Zeta", "alpha", "Beta"], [], ["alpha", "Beta", "Zeta"]),
@@ -21,19 +26,20 @@ class TestSlotUsageGenerationError:
         ],
     )
     def test_sorts_inputs(
-        self, missing, constraint, expected_missing, expected_constraint
+        self, missing, disallowed, expected_missing, expected_disallowed
     ):
         err = SlotUsageGenerationError(
             missing_meta_slots=missing,
-            varied_constraint_meta_slots=constraint,
+            disallowed_varied_constraint_meta_slots=disallowed,
         )
         assert err.missing_meta_slots == expected_missing
-        assert err.varied_constraint_meta_slots == expected_constraint
+        assert err.disallowed_varied_constraint_meta_slots == expected_disallowed
 
     def test_raises_value_error_when_both_empty(self):
         with pytest.raises(ValueError, match="must be non-empty"):
             SlotUsageGenerationError(
-                missing_meta_slots=[], varied_constraint_meta_slots=[]
+                missing_meta_slots=[],
+                disallowed_varied_constraint_meta_slots=[],
             )
 
     def test_raises_value_error_when_both_none(self):
@@ -41,39 +47,40 @@ class TestSlotUsageGenerationError:
             SlotUsageGenerationError()
 
     @pytest.mark.parametrize(
-        ("missing", "constraint"),
+        ("missing", "disallowed"),
         [
             (["c", "a"], None),
             (None, ["z", "x"]),
         ],
     )
-    def test_str(self, missing, constraint):
+    def test_str(self, missing, disallowed):
         err = SlotUsageGenerationError(
             missing_meta_slots=missing,
-            varied_constraint_meta_slots=constraint,
+            disallowed_varied_constraint_meta_slots=disallowed,
         )
         expected = (
             f"Target slot definition has missing meta slots, "
-            f"{err.missing_meta_slots}, and varied constraint meta slots, "
-            f"{err.varied_constraint_meta_slots}"
+            f"{err.missing_meta_slots}, and disallowed varied constraint "
+            f"meta slots, {err.disallowed_varied_constraint_meta_slots}"
         )
         assert str(err) == expected
 
     @pytest.mark.parametrize(
-        ("missing", "constraint"),
+        ("missing", "disallowed"),
         [
             (["c", "a"], None),
             (None, ["z", "x"]),
         ],
     )
-    def test_repr(self, missing, constraint):
+    def test_repr(self, missing, disallowed):
         err = SlotUsageGenerationError(
             missing_meta_slots=missing,
-            varied_constraint_meta_slots=constraint,
+            disallowed_varied_constraint_meta_slots=disallowed,
         )
         expected = (
             f"SlotUsageGenerationError"
             f"(missing_meta_slots={err.missing_meta_slots!r}, "
-            f"varied_constraint_meta_slots={err.varied_constraint_meta_slots!r})"
+            f"disallowed_varied_constraint_meta_slots="
+            f"{err.disallowed_varied_constraint_meta_slots!r})"
         )
         assert repr(err) == expected

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -603,7 +603,7 @@ class TestGetSlotUsageEntry:
             "base",
             "target",
             "expected_missing",
-            "expected_constraint_varied",
+            "expected_disallowed_varied_constraint",
             "expected_return",
         ),
         [
@@ -661,7 +661,31 @@ class TestGetSlotUsageEntry:
                 [],
                 SlotDefinition("a", title="T2", required=True),
             ),
-            # Constraint varied property still raises
+            # Allowed monotonic refinement: required False -> True
+            (
+                SlotDefinition("a", required=False),
+                SlotDefinition("a", required=True),
+                [],
+                [],
+                SlotDefinition("a", required=True),
+            ),
+            # Allowed refinement combined with extended + overridable changes
+            (
+                SlotDefinition("a", required=False, description="old"),
+                SlotDefinition("a", required=True, description="new", title="T"),
+                [],
+                [],
+                SlotDefinition("a", required=True, description="new", title="T"),
+            ),
+            # Disallowed: required True -> False (loosening)
+            (
+                SlotDefinition("a", required=True),
+                SlotDefinition("a", required=False),
+                [],
+                ["required"],
+                None,
+            ),
+            # Other constraint varied property still raises
             (
                 SlotDefinition("a", range="integer"),
                 SlotDefinition("a", range="string"),
@@ -669,10 +693,20 @@ class TestGetSlotUsageEntry:
                 ["range"],
                 None,
             ),
-            # Mixed constraint + non-constraint varied: only constraint reported
+            # Mixed disallowed constraint + non-constraint varied:
+            # only the disallowed constraint change is reported
             (
                 SlotDefinition("a", range="integer", description="old"),
                 SlotDefinition("a", range="string", description="new"),
+                [],
+                ["range"],
+                None,
+            ),
+            # Mixed: allowed `required` refinement coexists with a disallowed
+            # `range` change. Only the disallowed one is reported.
+            (
+                SlotDefinition("a", required=False, range="integer"),
+                SlotDefinition("a", required=True, range="string"),
                 [],
                 ["range"],
                 None,
@@ -684,15 +718,18 @@ class TestGetSlotUsageEntry:
         base,
         target,
         expected_missing,
-        expected_constraint_varied,
+        expected_disallowed_varied_constraint,
         expected_return,
     ):
-        if expected_missing or expected_constraint_varied:
+        if expected_missing or expected_disallowed_varied_constraint:
             with pytest.raises(SlotUsageGenerationError) as exc_info:
                 get_slot_usage_entry(base, target)
             error = exc_info.value
             assert error.missing_meta_slots == expected_missing
-            assert error.varied_constraint_meta_slots == expected_constraint_varied
+            assert (
+                error.disallowed_varied_constraint_meta_slots
+                == expected_disallowed_varied_constraint
+            )
         else:
             assert get_slot_usage_entry(base, target) == expected_return
 


### PR DESCRIPTION
## Summary

- `get_slot_usage_entry` now emits a `slot_usage` entry when the only constraint-meta-slot difference between base and target is `required` going from `False` to `True` (a monotonic tightening), rather than unconditionally raising `SlotUsageGenerationError` on any `SlotExpression` field difference.
- Adds `_is_allowed_constraint_refinement` as the single source of truth for which constraint-meta-slot changes can be safely emitted; currently allows only `required: False -> True`. All other constraint-property changes (and any meta slot missing from target) still raise `SlotUsageGenerationError`.
- Renames the exception's `varied_constraint_meta_slots` attribute/parameter to `disallowed_varied_constraint_meta_slots` since allowed monotonic refinements no longer appear in it.

## Background

LinkML's spec describes schemas as [monotonic](https://linkml.io/linkml/schemas/slots.html#slot-usage): `slot_usage` should *refine* (tighten) inherited constraints, never loosen or replace them. The LinkML runtime does not currently enforce monotonicity (`SchemaView.induced_slot` does last-writer-wins replacement for nearly every meta-slot), and maintainers acknowledge the gap — see [linkml/linkml#1508](https://github.com/linkml/linkml/issues/1508).

This PR conservatively starts emitting only the case that is unambiguously a safe monotonic tightening (`required: False -> True`), which resolves several `SlotUsageGenerationError` notes that appear when translating `dandischema.models` (e.g., on `Dandiset.{contributor,description,id,license,name}`, `Asset.contentUrl`, `Person.name`, `PublishedDandiset.url`).

Other potentially-safe directions (`range` narrowing to a subclass, adding a `pattern` where none existed, etc.) and clearly-non-monotonic ones (`pattern` replacement, `multivalued` changes in either direction, `required: True -> False`) are still rejected. A follow-up issue will be filed to track the broader spec-vs-implementation gap and document the rationale for these per-meta-slot decisions.

## Test plan

- [x] Updated unit tests in `tests/test_tools.py::TestSlotUsageEntry` cover the new allowed `required: False -> True` case (alone, combined with extensions, combined with non-constraint overrides) and the new mixed allowed-refinement + disallowed-change case
- [x] Updated unit tests in `tests/test_exceptions.py` for the renamed attribute/parameter (sorting, `__str__`, `__repr__`, empty-input `ValueError`)
- [x] `hatch run test.py3.10:pytest` — 3657 passed, 14 xfailed
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — all files formatted
- [x] `codespell` — clean
- [x] `hatch run types:check` — no new errors (only pre-existing linkml `import-untyped`)