### PR TITLE
Translate Pydantic `json_schema_extra={"readOnly": True}` to LinkML `readonly`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,14 @@ Options:
 2. **`gen_linkml.py`** — Main translation logic:
    - `translate_defs(module_names)` — top-level entry point; loads modules, fetches defs, runs `LinkmlGenerator`
    - `LinkmlGenerator` — single-use class; converts a collection of Pydantic models and enums into a `SchemaDefinition`. Call `generate()` once per instance.
-   - `SlotGenerator` — single-use class; translates a single Pydantic `CoreSchema` into a `SlotDefinition`. Dispatches on schema `type` strings via handler methods. Handles nesting, optionality, lists, unions, literals, UUIDs, dates, etc.
+   - `SlotGenerator` — single-use class; translates a single Pydantic
+     `CoreSchema` into a `SlotDefinition`. Dispatches on schema `type`
+     strings via handler methods. Handles nesting, optionality, lists,
+     unions, literals, UUIDs, dates, etc. Field-level `FieldInfo`
+     metadata is mapped to LinkML meta slots: `title`, `description`,
+     and `readonly` (the last set from
+     `json_schema_extra={"readOnly": True}` to a fixed reason string
+     paraphrasing the JSON Schema 2019-09 §9.4 semantic).
    - `any_class_def` — module-level `ClassDefinition` constant for the LinkML `Any` type
 
 3. **`cli/`** — Typer-based CLI wrapping `translate_defs`; `cli/__init__.py`

--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -447,9 +447,10 @@ class SlotGenerator:
         if self._used:
             raise GeneratorReuseError(self)
 
-        # Field-level properties (`required`, `title`, `description`) are only
-        # appropriate when translating the schema of the field itself, not a
-        # sub-schema in the schema of the field (e.g., a choice in a union type).
+        # Field-level properties (`required`, `title`, `description`,
+        # `readonly`) are only appropriate when translating the schema of the
+        # field itself, not a sub-schema in the schema of the field (e.g., a
+        # choice in a union type).
         if not self._field_schema.is_subschema:
             # Initialized the `required` meta slot to `True` since all
             # Pydantic fields are required unless a default value is provided
@@ -461,6 +462,20 @@ class SlotGenerator:
                 self._slot.title = field_info.title
             if field_info.description is not None:
                 self._slot.description = field_info.description
+
+            # Translate Pydantic `json_schema_extra={"readOnly": True}` into a
+            # LinkML `readonly` meta slot value. LinkML's `readonly` is a
+            # free-text string ("If present, slot is read only. Text
+            # explains why."), so emit a description paraphrasing the
+            # JSON Schema 2019-09 §9.4 `readOnly` semantic.
+            match field_info.json_schema_extra:
+                case {"readOnly": True}:
+                    self._slot.readonly = (
+                        "Managed exclusively by the owning authority; "
+                        "attempts by another entity to modify the value are "
+                        "expected to be ignored or rejected by that owning "
+                        "authority"
+                    )
 
         # Shape the contained slot according to core schema of the corresponding field
         self._shape_slot(self._field_schema.schema)

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -755,7 +755,9 @@ class TestSlotGenerator:
                 # This is needed due to Pydantic's behavior:
                 # The any argument for `min_length` of `conlist` that is less than
                 # or equal to 0 is ignored.
-                None if (min_len is not None and min_len <= 0) else min_len
+                None
+                if (min_len is not None and min_len <= 0)
+                else min_len
             )
             assert slot.maximum_cardinality == max_len
             assert slot.range == expected_range
@@ -1205,3 +1207,54 @@ class TestSlotGenerator:
         assert slot.required is None
         assert slot.title is None
         assert slot.description is None
+
+    _READONLY_TEXT = (
+        "Managed exclusively by the owning authority; "
+        "attempts by another entity to modify the value are "
+        "expected to be ignored or rejected by that owning "
+        "authority"
+    )
+
+    @pytest.mark.parametrize(
+        ("jse", "expected_readonly"),
+        [
+            ({"readOnly": True}, _READONLY_TEXT),
+            ({"readOnly": True, "other": "value"}, _READONLY_TEXT),
+            ({"readOnly": False}, None),
+            ({"readOnly": "yes"}, None),
+            ({"other": "value"}, None),
+            ({}, None),
+            (None, None),
+        ],
+    )
+    def test_readonly_from_json_schema_extra(self, jse, expected_readonly):
+        field_kwargs = {}
+        if jse is not None:
+            field_kwargs["json_schema_extra"] = jse
+
+        class Foo(BaseModel):
+            x: str = Field(**field_kwargs)
+
+        slot = translate_field_to_slot(Foo, "x")
+
+        assert slot.readonly == expected_readonly
+
+    def test_readonly_not_set_for_callable_json_schema_extra(self):
+        def _extra(schema):
+            schema["readOnly"] = True
+
+        class Foo(BaseModel):
+            x: str = Field(json_schema_extra=_extra)
+
+        slot = translate_field_to_slot(Foo, "x")
+
+        assert slot.readonly is None
+
+    def test_subschema_excludes_readonly(self):
+        class Foo(BaseModel):
+            x: str = Field(json_schema_extra={"readOnly": True})
+
+        field_schema = get_field_schema(Foo, "x")._replace(is_subschema=True)
+        slot = SlotGenerator(field_schema).generate()
+
+        assert slot.readonly is None


### PR DESCRIPTION
## Summary

- Map Pydantic `Field(..., json_schema_extra={"readOnly": True})` to a
  LinkML `readonly` meta slot value paraphrasing the JSON Schema
  2019-09 §9.4 semantic. (LinkML's `readonly` is a free-text reason
  string, not a boolean, so we emit a fixed reason.) Other shapes of
  `json_schema_extra` are ignored.
- Subschemas (e.g., union choices) skip this, matching the existing
  treatment of `title` / `description`.
- Context in #68 (this PR is a fourth option not enumerated there:
  map at the Pydantic → LinkML step using LinkML's native `readonly`).
  Pairs with linkml/linkml#3528.

## Test plan

- [x] New `TestSlotGenerator` tests: parametrized truthy/falsy/missing
  `readOnly` cases, callable `json_schema_extra` ignored, subschemas
  excluded.
- [x] `hatch run test.py3.10:pytest tests/` — 3666 passed, 14 xfailed.
- [x] `ruff check .` clean; `hatch run types:check` no new errors.
- [x] Smoke-tested against `dandischema.models`: 22 top-level slots
  and 8 `slot_usage` entries get `readonly`.
