### PR TITLE
Shorten the `readonly` meta slot reason string

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -466,16 +466,11 @@ class SlotGenerator:
             # Translate Pydantic `json_schema_extra={"readOnly": True}` into a
             # LinkML `readonly` meta slot value. LinkML's `readonly` is a
             # free-text string ("If present, slot is read only. Text
-            # explains why."), so emit a description paraphrasing the
-            # JSON Schema 2019-09 §9.4 `readOnly` semantic.
+            # explains why."), so emit a short reason capturing the JSON
+            # Schema 2019-09 §9.4 `readOnly` semantic.
             match field_info.json_schema_extra:
                 case {"readOnly": True}:
-                    self._slot.readonly = (
-                        "Managed exclusively by the owning authority; "
-                        "attempts by another entity to modify the value are "
-                        "expected to be ignored or rejected by that owning "
-                        "authority"
-                    )
+                    self._slot.readonly = "Read-only for clients; managed by server"
 
         # Shape the contained slot according to core schema of the corresponding field
         self._shape_slot(self._field_schema.schema)

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -1208,12 +1208,7 @@ class TestSlotGenerator:
         assert slot.title is None
         assert slot.description is None
 
-    _READONLY_TEXT = (
-        "Managed exclusively by the owning authority; "
-        "attempts by another entity to modify the value are "
-        "expected to be ignored or rejected by that owning "
-        "authority"
-    )
+    _READONLY_TEXT = "Read-only for clients; managed by server"
 
     @pytest.mark.parametrize(
         ("jse", "expected_readonly"),


### PR DESCRIPTION
## Summary

- Replace the verbose JSON Schema 2019-09 §9.4 paraphrase emitted as
  the `readonly` meta slot value for Pydantic
  `json_schema_extra={"readOnly": True}` fields (introduced in #69)
  with the more concise `"Read-only for clients; managed by server"`,
  which captures the same operative semantic.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/test_gen_linkml.py -k "readonly or readOnly"` — 9 passed.
