### PR TITLE
Include meta slot values in slot_usage discrepancy notes

### DIFF
--- a/src/pydantic2linkml/tools.py
+++ b/src/pydantic2linkml/tools.py
@@ -631,7 +631,7 @@ def get_slot_usage_entry(
             format_note(
                 f"Cannot express in a slot_usage entry the absence of the "
                 f"`{p}` meta slot, which is present in the base slot "
-                f"definition."
+                f"definition (base value: {getattr(base, p)!r})."
             )
         )
     for p in disallowed_varied_constraint:
@@ -639,7 +639,9 @@ def get_slot_usage_entry(
             format_note(
                 f"Cannot express in a slot_usage entry a value for the "
                 f"`{p}` constraint meta slot that differs from the base by a "
-                f"change that is not an allowed monotonic refinement."
+                f"change that is not an allowed monotonic refinement (base "
+                f"value: {getattr(base, p)!r}; target value: "
+                f"{getattr(target, p)!r})."
             )
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -599,19 +599,20 @@ class TestGetSlotUsageEntry:
             get_slot_usage_entry(base, target)
 
     @staticmethod
-    def _missing_note(meta_slot: str) -> str:
+    def _missing_note(meta_slot: str, base_value) -> str:
         return format_note(
             f"Cannot express in a slot_usage entry the absence of the "
             f"`{meta_slot}` meta slot, which is present in the base slot "
-            f"definition."
+            f"definition (base value: {base_value!r})."
         )
 
     @staticmethod
-    def _disallowed_note(meta_slot: str) -> str:
+    def _disallowed_note(meta_slot: str, base_value, target_value) -> str:
         return format_note(
             f"Cannot express in a slot_usage entry a value for the "
             f"`{meta_slot}` constraint meta slot that differs from the base "
-            f"by a change that is not an allowed monotonic refinement."
+            f"by a change that is not an allowed monotonic refinement (base "
+            f"value: {base_value!r}; target value: {target_value!r})."
         )
 
     @pytest.mark.parametrize(
@@ -684,7 +685,10 @@ class TestGetSlotUsageEntry:
                 SlotDefinition(
                     "a",
                     notes=sorted(
-                        [_missing_note("range"), _missing_note("required")],
+                        [
+                            _missing_note("range", "integer"),
+                            _missing_note("required", True),
+                        ],
                         key=str.casefold,
                     ),
                 ),
@@ -693,13 +697,17 @@ class TestGetSlotUsageEntry:
             (
                 SlotDefinition("a", required=True),
                 SlotDefinition("a", required=False),
-                SlotDefinition("a", notes=[_disallowed_note("required")]),
+                SlotDefinition(
+                    "a", notes=[_disallowed_note("required", True, False)]
+                ),
             ),
             # Disallowed `range` change
             (
                 SlotDefinition("a", range="integer"),
                 SlotDefinition("a", range="string"),
-                SlotDefinition("a", notes=[_disallowed_note("range")]),
+                SlotDefinition(
+                    "a", notes=[_disallowed_note("range", "integer", "string")]
+                ),
             ),
             # Mixed disallowed constraint + non-constraint varied:
             # the non-constraint override is still emitted alongside the note.
@@ -709,7 +717,7 @@ class TestGetSlotUsageEntry:
                 SlotDefinition(
                     "a",
                     description="new",
-                    notes=[_disallowed_note("range")],
+                    notes=[_disallowed_note("range", "integer", "string")],
                 ),
             ),
             # Mixed: allowed `required` refinement coexists with a disallowed
@@ -721,7 +729,7 @@ class TestGetSlotUsageEntry:
                 SlotDefinition(
                     "a",
                     required=True,
-                    notes=[_disallowed_note("range")],
+                    notes=[_disallowed_note("range", "integer", "string")],
                 ),
             ),
         ],


### PR DESCRIPTION
When a discrepancy cannot be expressed in a slot_usage entry, the note now also reports the relevant meta slot values: the base value for a meta slot the target is missing, and both the base and target values for a constraint meta slot whose change is not an allowed monotonic refinement.

Follow-up to #71.

## Test plan

- [x] `hatch run test.py3.10:pytest tests/` — all pass
- [x] `ruff check .` — clean
- [x] `hatch run types:check` — no new errors
- [x] CI across the Python 3.10–3.13 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
