### PR TITLE
Correct inverted condition for the inf/nan translation note

### DIFF
--- a/src/pydantic2linkml/gen_linkml.py
+++ b/src/pydantic2linkml/gen_linkml.py
@@ -582,10 +582,16 @@ class SlotGenerator:
             restriction
         """
         self._slot.range = "float"
-        if "allow_inf_nan" not in schema or schema["allow_inf_nan"]:
+        # A Pydantic `float` defaults to `allow_inf_nan=True` (inf/nan permitted),
+        # and the key is present in the core schema only when set explicitly. LinkML
+        # cannot express a restriction forbidding these values, so warn only when the
+        # source forbids them (`allow_inf_nan=False`); the permissive default needs no
+        # note, since the LinkML translation permits inf/nan regardless.
+        if schema.get("allow_inf_nan") is False:
             self._attach_note(
-                "LinkML does not have support for `'+inf'`, `'-inf'`, and `'NaN'` "
-                "values. Support for these values is not translated."
+                "LinkML cannot express the restriction disallowing `'+inf'`, "
+                "`'-inf'`, and `'NaN'` values; these values are accepted by the "
+                "translated schema despite the source restriction."
             )
         if "multiple_of" in schema:
             self._attach_note(
@@ -618,10 +624,15 @@ class SlotGenerator:
         """
         self._slot.range = "decimal"
 
-        if schema.get("allow_inf_nan"):
+        # A Pydantic `Decimal` defaults to `allow_inf_nan=False` (inf/nan forbidden),
+        # and the key is present in the core schema only when set explicitly. LinkML
+        # cannot express that restriction, so warn whenever the source forbids these
+        # values — i.e. by default (key absent) or explicitly (`allow_inf_nan=False`).
+        if not schema.get("allow_inf_nan"):
             self._attach_note(
-                "LinkML does not have support for `'+inf'`, `'-inf'`, and `'NaN'` "
-                "values. Support for these values is not translated."
+                "LinkML cannot express the restriction disallowing `'+inf'`, "
+                "`'-inf'`, and `'NaN'` values; these values are accepted by the "
+                "translated schema despite the source restriction."
             )
         if "multiple_of" in schema:
             self._attach_note(

--- a/tests/test_gen_linkml.py
+++ b/tests/test_gen_linkml.py
@@ -306,9 +306,11 @@ class TestSlotGenerator:
         verify_notes = partial(verify_str_lst, str_lst=slot.notes)
 
         assert slot.range == "float"
+        # `float` permits inf/nan by default (allow_inf_nan=True); the note flags the
+        # untranslatable restriction, so it fires only when explicitly forbidden.
         verify_notes(
-            "LinkML does not have support for `'+inf'`, `'-inf'`, and `'NaN'`",
-            allow_inf_nan is None or allow_inf_nan,
+            "restriction disallowing `'+inf'`, `'-inf'`, and `'NaN'`",
+            allow_inf_nan is False,
         )
         verify_notes(f"multiple of {multiple_of}", multiple_of is not None)
         assert slot.maximum_value == le
@@ -347,9 +349,11 @@ class TestSlotGenerator:
         verify_notes = partial(verify_str_lst, str_lst=slot.notes)
 
         assert slot.range == "decimal"
+        # `Decimal` forbids inf/nan by default (allow_inf_nan=False); the note flags the
+        # untranslatable restriction, so it fires whenever forbidden (default or False).
         verify_notes(
-            "LinkML does not have support for `'+inf'`, `'-inf'`, and `'NaN'`",
-            allow_inf_nan,
+            "restriction disallowing `'+inf'`, `'-inf'`, and `'NaN'`",
+            not allow_inf_nan,
         )
         verify_notes(f"max number of {max_digits} digits", max_digits is not None)
         verify_notes(


### PR DESCRIPTION
## Summary

The note warning that LinkML can't represent `'+inf'`/`'-inf'`/`'NaN'` was attached under an inverted condition in both `_float_schema` and `_decimal_schema`. It fired when a field *permitted* inf/nan and stayed silent when a field *forbade* them — the opposite of where a translation gap actually exists.

A LinkML `float`/`decimal` slot, validated through LinkML's default (JSON Schema) path, **always accepts** inf/nan and cannot be made to reject them (no metamodel slot expresses it; the emitted `{"type": "number"}` accepts inf/nan under the `jsonschema` backend). So the only thing lost in translation is a *restriction* (`allow_inf_nan=False`):

- when the source **permits** inf/nan, LinkML faithfully permits them too → no note needed;
- when the source **forbids** inf/nan, LinkML silently accepts them → this is the gap worth a note.

This PR flips both conditions to warn iff the source forbids inf/nan, accounting for the opposite per-type defaults (`float` defaults to `allow_inf_nan=True`, `Decimal` to `allow_inf_nan=False`), and rewrites the note text to describe the actual gap.

## Changes

- `_float_schema`: note iff `allow_inf_nan` is explicitly `False`.
- `_decimal_schema`: note iff inf/nan are forbidden — by default (key absent) or explicitly `False`.
- New note wording: the disallowing restriction isn't translated, so the LinkML schema accepts the values regardless.
- Added comments documenting the per-type defaults, so the (still necessary) asymmetry between the two conditions no longer reads as a bug.
- Updated `test_float_schema` / `test_decimal_schema` accordingly.

## Behavior matrix (after)

Because LinkML always accepts inf/nan, the note now fires exactly on the rows where the source forbids them (the translation gap):

| source field | source forbids inf/nan? | LinkML can enforce that? | note fires? |
|---|---|---|---|
| `float` default / `=True` | no | n/a | no |
| `float` `=False` | yes | no | **yes** |
| `Decimal` default / `=False` | yes | no | **yes** |
| `Decimal` `=True` | no | n/a | no |

<details>
<summary>Caveat: float vs. decimal across consumers</summary>

The generated **Pydantic** artifact diverges from the JSON-Schema path for `decimal`: `gen-pydantic` emits a real `Decimal`, which honors Pydantic's `allow_inf_nan=False` default and *rejects* inf/nan — so the two LinkML-derived consumers disagree for `decimal`, and no single note can be correct for both at once. The note here is defined relative to LinkML's native/JSON-Schema validation path. For `float` there's no such conflict (the generated bare `float` re-defaults to `True` and accepts, matching the JSON-Schema path).

</details>

## Test plan

- [x] `test_float_schema` / `test_decimal_schema` pass under the new conditions
- [x] Full suite: 3656 passed, 14 xfailed
- [x] `ruff check` clean on changed files
- [x] mypy: no new errors in changed lines (pre-existing errors are unrelated: missing `linkml_runtime` stubs, etc.)
